### PR TITLE
Make auth of getter methods in store-vault-server/withdrawal-server to be reusable

### DIFF
--- a/.sqlx/query-17e83c47256da932aa063a002e8ab699df94bd1b168cc090dce01cbe1733fe1b.json
+++ b/.sqlx/query-17e83c47256da932aa063a002e8ab699df94bd1b168cc090dce01cbe1733fe1b.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n                SELECT uuid, timestamp, encrypted_data\n                FROM encrypted_data\n                WHERE data_type = $1 AND pubkey = $2 AND (timestamp, uuid) > ($3, $4)\n                ORDER BY timestamp ASC, uuid ASC\n                LIMIT $5\n                ",
+  "query": "\n            SELECT uuid, timestamp, encrypted_data\n            FROM encrypted_data\n            WHERE data_type = $1 \n            AND pubkey = $2 \n            AND (timestamp, uuid) > ($3, $4)\n            ORDER BY timestamp ASC, uuid ASC\n            LIMIT $5\n        ",
   "describe": {
     "columns": [
       {
@@ -34,5 +34,5 @@
       false
     ]
   },
-  "hash": "77686aaddfcfaeae2eab4fafb3585fcf14ed6804e8e893659222b4df0d49b25c"
+  "hash": "17e83c47256da932aa063a002e8ab699df94bd1b168cc090dce01cbe1733fe1b"
 }

--- a/.sqlx/query-5602b16bb2e9bd52ff4b0df870d25694e0fd5c06408fa0521d8a0fe46dac961b.json
+++ b/.sqlx/query-5602b16bb2e9bd52ff4b0df870d25694e0fd5c06408fa0521d8a0fe46dac961b.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n                SELECT uuid, timestamp, encrypted_data\n                FROM encrypted_data\n                WHERE data_type = $1 AND pubkey = $2\n                ORDER BY timestamp ASC, uuid ASC\n                LIMIT $3\n                ",
+  "query": "\n            SELECT uuid, timestamp, encrypted_data\n            FROM encrypted_data\n            WHERE data_type = $1 \n            AND pubkey = $2 \n            AND (timestamp, uuid) < ($3, $4)\n            ORDER BY timestamp DESC, uuid DESC\n            LIMIT $5\n        ",
   "describe": {
     "columns": [
       {
@@ -23,6 +23,8 @@
       "Left": [
         "Int4",
         "Text",
+        "Int8",
+        "Text",
         "Int8"
       ]
     },
@@ -32,5 +34,5 @@
       false
     ]
   },
-  "hash": "b71f0b5b0cc58e0d60f5f5b9e3c4f7d5af896b3db6992869ceb2e1ab2d6e2ba0"
+  "hash": "5602b16bb2e9bd52ff4b0df870d25694e0fd5c06408fa0521d8a0fe46dac961b"
 }

--- a/client-sdk/src/external_api/store_vault_server.rs
+++ b/client-sdk/src/external_api/store_vault_server.rs
@@ -5,7 +5,7 @@ use intmax2_interfaces::{
         store_vault_server::{
             interface::{DataType, SaveDataEntry, StoreVaultClientInterface},
             types::{
-                DataWithMetaData, GetDataBatchRequest, GetDataBatchResponse,
+                CursorOrder, DataWithMetaData, GetDataBatchRequest, GetDataBatchResponse,
                 GetDataSequenceRequest, GetDataSequenceResponse, GetSenderProofSetRequest,
                 GetSenderProofSetResponse, GetUserDataRequest, GetUserDataResponse, MetaDataCursor,
                 MetaDataCursorResponse, SaveDataBatchRequest, SaveDataBatchResponse,
@@ -170,6 +170,7 @@ impl StoreVaultServerClient {
             data_type,
             cursor: MetaDataCursor {
                 cursor: metadata_cursor.clone(),
+                order: CursorOrder::Asc,
                 limit: None,
             },
         };

--- a/interfaces/src/api/error.rs
+++ b/interfaces/src/api/error.rs
@@ -3,6 +3,9 @@ pub enum ServerError {
     #[error("Env error: {0}")]
     EnvError(String),
 
+    #[error("Invalid auth: {0}")]
+    InvalidAuth(String),
+
     #[error("Network error: {0}")]
     NetworkError(String),
 

--- a/interfaces/src/api/store_vault_server/types.rs
+++ b/interfaces/src/api/store_vault_server/types.rs
@@ -1,3 +1,8 @@
+use std::{
+    fmt::{self, Display, Formatter},
+    str::FromStr,
+};
+
 use super::interface::{DataType, SaveDataEntry};
 use crate::{data::meta_data::MetaData, utils::signature::Signable};
 use intmax2_zkp::ethereum_types::bytes32::Bytes32;
@@ -155,11 +160,32 @@ pub struct MetaDataCursor {
     pub limit: Option<u32>,
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
 pub enum CursorOrder {
     #[default]
     Asc,
     Desc,
+}
+
+impl Display for CursorOrder {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            CursorOrder::Asc => write!(f, "asc"),
+            CursorOrder::Desc => write!(f, "desc"),
+        }
+    }
+}
+
+impl FromStr for CursorOrder {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "asc" => Ok(CursorOrder::Asc),
+            "desc" => Ok(CursorOrder::Desc),
+            _ => Err(format!("Invalid CursorOrder: {}", s)),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/interfaces/src/api/store_vault_server/types.rs
+++ b/interfaces/src/api/store_vault_server/types.rs
@@ -4,6 +4,13 @@ use intmax2_zkp::ethereum_types::bytes32::Bytes32;
 use serde::{Deserialize, Serialize};
 use serde_with::{base64::Base64, serde_as};
 
+// a prefix to make the content unique
+fn content_prefix(path: &str) -> Vec<u8> {
+    format!("intmax2/v1/store-vault-server/{}", path)
+        .as_bytes()
+        .to_vec()
+}
+
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -15,7 +22,11 @@ pub struct SaveUserDataRequest {
 
 impl Signable for SaveUserDataRequest {
     fn content(&self) -> Vec<u8> {
-        bincode::serialize(&(self.data.clone(), self.prev_digest)).unwrap()
+        [
+            content_prefix("save_user_data"),
+            bincode::serialize(&(self.data.clone(), self.prev_digest)).unwrap(),
+        ]
+        .concat()
     }
 }
 
@@ -25,7 +36,7 @@ pub struct GetUserDataRequest;
 
 impl Signable for GetUserDataRequest {
     fn content(&self) -> Vec<u8> {
-        vec![]
+        content_prefix("get_user_data")
     }
 }
 
@@ -47,7 +58,11 @@ pub struct SaveSenderProofSetRequest {
 
 impl Signable for SaveSenderProofSetRequest {
     fn content(&self) -> Vec<u8> {
-        bincode::serialize(&self.data).unwrap()
+        [
+            content_prefix("save_sender_proof_set"),
+            bincode::serialize(&self.data).unwrap(),
+        ]
+        .concat()
     }
 }
 
@@ -57,7 +72,7 @@ pub struct GetSenderProofSetRequest;
 
 impl Signable for GetSenderProofSetRequest {
     fn content(&self) -> Vec<u8> {
-        vec![]
+        content_prefix("get_sender_proof_set")
     }
 }
 
@@ -77,7 +92,11 @@ pub struct SaveDataBatchRequest {
 
 impl Signable for SaveDataBatchRequest {
     fn content(&self) -> Vec<u8> {
-        bincode::serialize(&self.data).unwrap()
+        [
+            content_prefix("save_data_batch"),
+            bincode::serialize(&self.data).unwrap(),
+        ]
+        .concat()
     }
 }
 
@@ -96,7 +115,8 @@ pub struct GetDataBatchRequest {
 
 impl Signable for GetDataBatchRequest {
     fn content(&self) -> Vec<u8> {
-        bincode::serialize(&(self.data_type, self.uuids.clone())).unwrap()
+        // to reuse the signature, we exclude data_type and uuids from the content intentionally
+        content_prefix("get_data_batch")
     }
 }
 
@@ -115,7 +135,8 @@ pub struct GetDataSequenceRequest {
 
 impl Signable for GetDataSequenceRequest {
     fn content(&self) -> Vec<u8> {
-        bincode::serialize(&(self.data_type, self.cursor.clone())).unwrap()
+        // to reuse the signature, we exclude data_type and cursor from the content intentionally
+        content_prefix("get_data_sequence")
     }
 }
 

--- a/interfaces/src/api/store_vault_server/types.rs
+++ b/interfaces/src/api/store_vault_server/types.rs
@@ -130,7 +130,15 @@ pub struct GetDataSequenceResponse {
 #[serde(rename_all = "camelCase")]
 pub struct MetaDataCursor {
     pub cursor: Option<MetaData>,
+    pub order: CursorOrder,
     pub limit: Option<u32>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub enum CursorOrder {
+    #[default]
+    Asc,
+    Desc,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/interfaces/src/api/withdrawal_server/types.rs
+++ b/interfaces/src/api/withdrawal_server/types.rs
@@ -13,6 +13,13 @@ type F = GoldilocksField;
 type C = PoseidonGoldilocksConfig;
 const D: usize = 2;
 
+// a prefix to make the content unique
+fn content_prefix(path: &str) -> Vec<u8> {
+    format!("intmax2/v1/withdrawal-server/{}", path)
+        .as_bytes()
+        .to_vec()
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetFeeResponse {
@@ -27,7 +34,11 @@ pub struct RequestWithdrawalRequest {
 
 impl Signable for RequestWithdrawalRequest {
     fn content(&self) -> Vec<u8> {
-        bincode::serialize(&self.single_withdrawal_proof).unwrap()
+        [
+            content_prefix("request_withdrawal"),
+            bincode::serialize(&self.single_withdrawal_proof).unwrap(),
+        ]
+        .concat()
     }
 }
 
@@ -39,7 +50,11 @@ pub struct RequestClaimRequest {
 
 impl Signable for RequestClaimRequest {
     fn content(&self) -> Vec<u8> {
-        bincode::serialize(&self.single_claim_proof).unwrap()
+        [
+            content_prefix("request_claim"),
+            bincode::serialize(&self.single_claim_proof).unwrap(),
+        ]
+        .concat()
     }
 }
 
@@ -49,7 +64,7 @@ pub struct GetWithdrawalInfoRequest;
 
 impl Signable for GetWithdrawalInfoRequest {
     fn content(&self) -> Vec<u8> {
-        vec![]
+        content_prefix("get_withdrawal_info")
     }
 }
 
@@ -65,7 +80,7 @@ pub struct GetClaimInfoRequest;
 
 impl Signable for GetClaimInfoRequest {
     fn content(&self) -> Vec<u8> {
-        vec![]
+        content_prefix("get_claim_info")
     }
 }
 

--- a/interfaces/src/utils/circuit_verifiers.rs
+++ b/interfaces/src/utils/circuit_verifiers.rs
@@ -72,7 +72,6 @@ impl CircuitVerifiers {
     }
 
     pub fn save(&self) -> anyhow::Result<()> {
-        // save_verifier_circuit_data(&spent_circuit_data_path(), &self.spent_vd)?;
         save_verifier_circuit_data(&balance_circuit_data_path(), &self.balance_vd)?;
         save_verifier_circuit_data(&validity_circuit_data_path(), &self.validity_vd)?;
         save_verifier_circuit_data(&transition_circuit_data_path(), &self.transition_vd)?;

--- a/store-vault-server/src/app/store_vault_server.rs
+++ b/store-vault-server/src/app/store_vault_server.rs
@@ -273,8 +273,8 @@ impl StoreVaultServer {
                 let timestamp = cursor
                     .cursor
                     .as_ref()
-                    .map(|c| c.timestamp)
-                    .unwrap_or_else(|| u64::MAX);
+                    .map(|c| c.timestamp as i64)
+                    .unwrap_or_else(|| i64::MAX);
                 let uuid = cursor
                     .cursor
                     .as_ref()
@@ -292,7 +292,7 @@ impl StoreVaultServer {
         "#,
                     data_type as i32,
                     pubkey_hex,
-                    timestamp as i64,
+                    timestamp,
                     uuid,
                     actual_limit + 1
                 )

--- a/store-vault-server/src/app/store_vault_server.rs
+++ b/store-vault-server/src/app/store_vault_server.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Ok, Result};
 use intmax2_interfaces::{
     api::store_vault_server::{
         interface::{DataType, SaveDataEntry},
-        types::{DataWithMetaData, MetaDataCursor, MetaDataCursorResponse},
+        types::{CursorOrder, DataWithMetaData, MetaDataCursor, MetaDataCursorResponse},
     },
     data::meta_data::MetaData,
     utils::digest::get_digest,
@@ -234,16 +234,18 @@ impl StoreVaultServer {
     ) -> Result<(Vec<DataWithMetaData>, MetaDataCursorResponse)> {
         let pubkey_hex = pubkey.to_hex();
         let actual_limit = cursor.limit.unwrap_or(self.config.max_pagination_limit) as i64;
-        let cursor_meta = cursor.cursor.as_ref();
-        let result = if let Some(cursor_meta) = cursor_meta {
-            let records = sqlx::query!(
+        let cursor_meta = cursor.cursor.clone().unwrap_or_default();
+        let result: Vec<DataWithMetaData> = match cursor.order {
+            CursorOrder::Asc => sqlx::query!(
                 r#"
-                SELECT uuid, timestamp, encrypted_data
-                FROM encrypted_data
-                WHERE data_type = $1 AND pubkey = $2 AND (timestamp, uuid) > ($3, $4)
-                ORDER BY timestamp ASC, uuid ASC
-                LIMIT $5
-                "#,
+            SELECT uuid, timestamp, encrypted_data
+            FROM encrypted_data
+            WHERE data_type = $1 
+            AND pubkey = $2 
+            AND (timestamp, uuid) > ($3, $4)
+            ORDER BY timestamp ASC, uuid ASC
+            LIMIT $5
+        "#,
                 data_type as i32,
                 pubkey_hex,
                 cursor_meta.timestamp as i64,
@@ -251,57 +253,55 @@ impl StoreVaultServer {
                 actual_limit + 1
             )
             .fetch_all(&self.pool)
-            .await?;
-            let result: Vec<DataWithMetaData> = records
-                .into_iter()
-                .map(|r| {
-                    let meta = MetaData {
-                        uuid: r.uuid,
-                        timestamp: r.timestamp as u64,
-                    };
-                    DataWithMetaData {
-                        meta,
-                        data: r.encrypted_data,
-                    }
-                })
-                .collect();
-            result
-        } else {
-            let records = sqlx::query!(
+            .await?
+            .into_iter()
+            .map(|r| {
+                let meta = MetaData {
+                    uuid: r.uuid,
+                    timestamp: r.timestamp as u64,
+                };
+                DataWithMetaData {
+                    meta,
+                    data: r.encrypted_data,
+                }
+            })
+            .collect(),
+            CursorOrder::Desc => sqlx::query!(
                 r#"
-                SELECT uuid, timestamp, encrypted_data
-                FROM encrypted_data
-                WHERE data_type = $1 AND pubkey = $2
-                ORDER BY timestamp ASC, uuid ASC
-                LIMIT $3
-                "#,
+            SELECT uuid, timestamp, encrypted_data
+            FROM encrypted_data
+            WHERE data_type = $1 
+            AND pubkey = $2 
+            AND (timestamp, uuid) < ($3, $4)
+            ORDER BY timestamp DESC, uuid DESC
+            LIMIT $5
+        "#,
                 data_type as i32,
                 pubkey_hex,
+                cursor_meta.timestamp as i64,
+                cursor_meta.uuid,
                 actual_limit + 1
             )
             .fetch_all(&self.pool)
-            .await?;
-            let result: Vec<DataWithMetaData> = records
-                .into_iter()
-                .map(|r| {
-                    let meta = MetaData {
-                        uuid: r.uuid,
-                        timestamp: r.timestamp as u64,
-                    };
-                    DataWithMetaData {
-                        meta,
-                        data: r.encrypted_data,
-                    }
-                })
-                .collect();
-            result
+            .await?
+            .into_iter()
+            .map(|r| {
+                let meta = MetaData {
+                    uuid: r.uuid,
+                    timestamp: r.timestamp as u64,
+                };
+                DataWithMetaData {
+                    meta,
+                    data: r.encrypted_data,
+                }
+            })
+            .collect(),
         };
-
+        let has_more = result.len() > actual_limit as usize;
         let result = result
             .into_iter()
             .take(actual_limit as usize)
             .collect::<Vec<DataWithMetaData>>();
-        let has_more = result.len() > actual_limit as usize;
         let next_cursor = result.last().map(|r| r.meta.clone());
         let total_count = sqlx::query_scalar!(
             r#"

--- a/wasm/js-test/src/main.ts
+++ b/wasm/js-test/src/main.ts
@@ -1,5 +1,5 @@
 import { cleanEnv, num, str, url } from 'envalid';
-import { Config, decrypt_deposit_data, fetch_deposit_history, fetch_transfer_history, fetch_tx_history, generate_intmax_account_from_eth_key, get_user_data, get_withdrawal_info, JsGenericAddress, JsTransfer, JsTxRequestMemo, prepare_deposit, query_and_finalize, send_tx_request, sync, sync_withdrawals, } from '../pkg';
+import { Config, fetch_deposit_history, fetch_transfer_history, fetch_tx_history, generate_intmax_account_from_eth_key, get_user_data, get_withdrawal_info, JsGenericAddress, JsTransfer, JsTxRequestMemo, prepare_deposit, query_and_finalize, send_tx_request, sync, sync_withdrawals, } from '../pkg';
 import { generateRandomHex } from './utils';
 import { deposit, getEthBalance } from './contract';
 import * as dotenv from 'dotenv';
@@ -194,9 +194,6 @@ async function sendTx(config: Config, block_builder_base_url: string, privateKey
 async function sleep(sec: number) {
   return new Promise((resolve) => setTimeout(resolve, sec * 1000));
 }
-
-
-
 
 main().then(() => {
   process.exit(0);

--- a/wasm/js-test/src/main.ts
+++ b/wasm/js-test/src/main.ts
@@ -1,5 +1,5 @@
 import { cleanEnv, num, str, url } from 'envalid';
-import { Config, fetch_deposit_history, fetch_transfer_history, fetch_tx_history, generate_intmax_account_from_eth_key, get_user_data, get_withdrawal_info, JsGenericAddress, JsTransfer, JsTxRequestMemo, prepare_deposit, query_and_finalize, send_tx_request, sync, sync_withdrawals, } from '../pkg';
+import { Config, decrypt_deposit_data, fetch_deposit_history, fetch_transfer_history, fetch_tx_history, generate_intmax_account_from_eth_key, get_user_data, get_withdrawal_info, JsGenericAddress, JsTransfer, JsTxRequestMemo, prepare_deposit, query_and_finalize, send_tx_request, sync, sync_withdrawals, } from '../pkg';
 import { generateRandomHex } from './utils';
 import { deposit, getEthBalance } from './contract';
 import * as dotenv from 'dotenv';

--- a/wasm/js-test/src/store_vault.ts
+++ b/wasm/js-test/src/store_vault.ts
@@ -1,0 +1,83 @@
+import { cleanEnv, num, str, url } from 'envalid';
+import { Config, fetch_encrypted_data, generate_auth_for_store_vault, generate_intmax_account_from_eth_key, } from '../pkg';
+import * as dotenv from 'dotenv';
+dotenv.config();
+
+const env = cleanEnv(process.env, {
+    USER_ETH_PRIVATE_KEY: str(),
+    ENV: str(),
+
+    // Base URLs
+    STORE_VAULT_SERVER_BASE_URL: url(),
+    BALANCE_PROVER_BASE_URL: url(),
+    VALIDITY_PROVER_BASE_URL: url(),
+    WITHDRAWAL_SERVER_BASE_URL: url(),
+    BLOCK_BUILDER_BASE_URL: url(),
+
+    // Timeout configurations
+    DEPOSIT_TIMEOUT: num(),
+    TX_TIMEOUT: num(),
+
+    // Block builder client configurations
+    BLOCK_BUILDER_REQUEST_INTERVAL: num(),
+    BLOCK_BUILDER_REQUEST_LIMIT: num(),
+    BLOCK_BUILDER_QUERY_WAIT_TIME: num(),
+    BLOCK_BUILDER_QUERY_INTERVAL: num(),
+    BLOCK_BUILDER_QUERY_LIMIT: num(),
+
+    // L1 configurations
+    L1_RPC_URL: url(),
+    L1_CHAIN_ID: num(),
+    LIQUIDITY_CONTRACT_ADDRESS: str(),
+
+    // L2 configurations
+    L2_RPC_URL: url(),
+    L2_CHAIN_ID: num(),
+    ROLLUP_CONTRACT_ADDRESS: str(),
+    ROLLUP_CONTRACT_DEPLOYED_BLOCK_NUMBER: num(),
+});
+
+async function main() {
+    const config = new Config(
+        env.STORE_VAULT_SERVER_BASE_URL,
+        env.BALANCE_PROVER_BASE_URL,
+        env.VALIDITY_PROVER_BASE_URL,
+        env.WITHDRAWAL_SERVER_BASE_URL,
+        BigInt(env.DEPOSIT_TIMEOUT),
+        BigInt(env.TX_TIMEOUT),
+        BigInt(env.BLOCK_BUILDER_REQUEST_INTERVAL),
+        BigInt(env.BLOCK_BUILDER_REQUEST_LIMIT),
+        BigInt(env.BLOCK_BUILDER_QUERY_WAIT_TIME),
+        BigInt(env.BLOCK_BUILDER_QUERY_INTERVAL),
+        BigInt(env.BLOCK_BUILDER_QUERY_LIMIT),
+        env.L1_RPC_URL,
+        BigInt(env.L1_CHAIN_ID),
+        env.LIQUIDITY_CONTRACT_ADDRESS,
+        env.L2_RPC_URL,
+        BigInt(env.L2_CHAIN_ID),
+        env.ROLLUP_CONTRACT_ADDRESS,
+        BigInt(env.ROLLUP_CONTRACT_DEPLOYED_BLOCK_NUMBER),
+    );
+
+    const ethKey = env.USER_ETH_PRIVATE_KEY;
+    const key = await generate_intmax_account_from_eth_key(ethKey);
+
+    // get auth for store vault using private key
+    const auth = await generate_auth_for_store_vault(key.privkey);
+    console.log(`auth: pubkey ${auth.pubkey}, expiry ${auth.expiry}`);
+
+    // get latest 10 encrypted data
+    const data = await fetch_encrypted_data(config, auth, undefined, undefined, 10, "asc");
+    console.log(`data.length: ${data.length}`);
+    for (const d of data) {
+        console.log(`type:${d.data_type} timestamp:${d.timestamp} uuid: ${d.uuid} data.length: ${d.data.length}`);
+    }
+}
+
+
+main().then(() => {
+    process.exit(0);
+}).catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/wasm/js-test/src/store_vault.ts
+++ b/wasm/js-test/src/store_vault.ts
@@ -61,13 +61,18 @@ async function main() {
 
     const ethKey = env.USER_ETH_PRIVATE_KEY;
     const key = await generate_intmax_account_from_eth_key(ethKey);
+    const privkey = key.privkey;
 
     // get auth for store vault using private key
-    const auth = await generate_auth_for_store_vault(key.privkey);
+    const auth = await generate_auth_for_store_vault(privkey);
     console.log(`auth: pubkey ${auth.pubkey}, expiry ${auth.expiry}`);
 
     // get latest 10 encrypted data
-    const data = await fetch_encrypted_data(config, auth, undefined, undefined, 10, "asc");
+    const timestamp = undefined;
+    const uuid = undefined;
+    const limit = 10;
+    const order = "desc"; // or "asc"
+    const data = await fetch_encrypted_data(config, auth, timestamp, uuid, limit, order);
     console.log(`data.length: ${data.length}`);
     for (const d of data) {
         console.log(`type:${d.data_type} timestamp:${d.timestamp} uuid: ${d.uuid} data.length: ${d.data.length}`);

--- a/wasm/src/js_types/auth.rs
+++ b/wasm/src/js_types/auth.rs
@@ -1,0 +1,63 @@
+use intmax2_interfaces::utils::signature::Auth;
+use intmax2_zkp::{
+    common::signature::flatten::FlatG2,
+    ethereum_types::{u256::U256, u32limb_trait::U32LimbTrait},
+};
+use wasm_bindgen::prelude::wasm_bindgen;
+
+#[derive(Debug, Clone)]
+#[wasm_bindgen(getter_with_clone)]
+pub struct JsFlatG2 {
+    pub elements: Vec<String>, // hex string
+}
+
+impl From<FlatG2> for JsFlatG2 {
+    fn from(flat_g2: FlatG2) -> Self {
+        Self {
+            elements: flat_g2.0.iter().map(|e| e.to_hex()).collect(),
+        }
+    }
+}
+
+impl TryFrom<JsFlatG2> for FlatG2 {
+    type Error = &'static str;
+
+    fn try_from(js_flat_g2: JsFlatG2) -> Result<Self, Self::Error> {
+        let elements = js_flat_g2
+            .elements
+            .iter()
+            .map(|e| U256::from_hex(e).map_err(|_| "Invalid hex string"))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self(elements.try_into().map_err(|_| "Invalid length")?))
+    }
+}
+
+#[derive(Debug, Clone)]
+#[wasm_bindgen(getter_with_clone)]
+pub struct JsAuth {
+    pub pubkey: String, // hex string
+    pub expiry: u64,
+    pub signature: JsFlatG2, // hex string
+}
+
+impl From<Auth> for JsAuth {
+    fn from(auth: Auth) -> Self {
+        Self {
+            pubkey: auth.pubkey.to_hex(),
+            expiry: auth.expiry,
+            signature: auth.signature.into(),
+        }
+    }
+}
+
+impl TryFrom<JsAuth> for Auth {
+    type Error = &'static str;
+
+    fn try_from(js_auth: JsAuth) -> Result<Self, Self::Error> {
+        Ok(Self {
+            pubkey: U256::from_hex(&js_auth.pubkey).map_err(|_| "Invalid hex string")?,
+            expiry: js_auth.expiry,
+            signature: FlatG2::try_from(js_auth.signature)?,
+        })
+    }
+}

--- a/wasm/src/js_types/encrypted_data.rs
+++ b/wasm/src/js_types/encrypted_data.rs
@@ -1,0 +1,1 @@
+pub struct JsEncryptedData {}

--- a/wasm/src/js_types/encrypted_data.rs
+++ b/wasm/src/js_types/encrypted_data.rs
@@ -1,1 +1,23 @@
-pub struct JsEncryptedData {}
+use intmax2_interfaces::api::store_vault_server::{interface::DataType, types::DataWithMetaData};
+use wasm_bindgen::prelude::wasm_bindgen;
+
+#[derive(Debug, Clone)]
+#[wasm_bindgen(getter_with_clone)]
+pub struct JsEncryptedData {
+    pub data: Vec<u8>,
+    pub uuid: String,
+    pub timestamp: u64,
+    /// Deposit, Transfer(Receive), Tx(Send)
+    pub data_type: String,
+}
+
+impl JsEncryptedData {
+    pub fn new(data_type: DataType, data_with_meta: DataWithMetaData) -> Self {
+        Self {
+            data: data_with_meta.data,
+            uuid: data_with_meta.meta.uuid,
+            timestamp: data_with_meta.meta.timestamp,
+            data_type: data_type.to_string(),
+        }
+    }
+}

--- a/wasm/src/js_types/mod.rs
+++ b/wasm/src/js_types/mod.rs
@@ -1,5 +1,7 @@
+pub mod auth;
 pub mod common;
 pub mod data;
+pub mod encrypted_data;
 pub mod history;
 pub mod utils;
 pub mod wrapper;

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -3,12 +3,7 @@ use intmax2_client_sdk::{
     client::key_from_eth::generate_intmax_account_from_eth_key as inner_generate_intmax_account_from_eth_key,
     external_api::utils::time::sleep_for,
 };
-use intmax2_interfaces::data::{
-    deposit_data::{DepositData, TokenType},
-    encryption::Encryption as _,
-    transfer_data::TransferData,
-    tx_data::TxData,
-};
+use intmax2_interfaces::data::deposit_data::TokenType;
 use intmax2_zkp::{
     common::transfer::Transfer,
     constants::NUM_TRANSFERS_IN_TX,
@@ -16,7 +11,7 @@ use intmax2_zkp::{
 };
 use js_types::{
     common::{JsClaimInfo, JsMining, JsTransfer, JsWithdrawalInfo},
-    data::{JsDepositData, JsDepositResult, JsTransferData, JsTxData, JsTxResult, JsUserData},
+    data::{JsDepositResult, JsTxResult, JsUserData},
     history::{JsDepositEntry, JsTransferEntry, JsTxEntry},
     utils::{parse_address, parse_u256},
     wrapper::JsTxRequestMemo,
@@ -27,6 +22,7 @@ use wasm_bindgen::{prelude::wasm_bindgen, JsError};
 
 pub mod client;
 pub mod js_types;
+pub mod native;
 pub mod utils;
 
 #[derive(Debug, Clone)]
@@ -286,41 +282,6 @@ pub async fn fetch_tx_history(
     let history = client.fetch_tx_history(key).await?;
     let js_history = history.into_iter().map(JsTxEntry::from).collect();
     Ok(js_history)
-}
-
-/// Decrypt the deposit data.
-#[wasm_bindgen]
-pub async fn decrypt_deposit_data(
-    private_key: &str,
-    data: &[u8],
-) -> Result<JsDepositData, JsError> {
-    init_logger();
-    let key = str_privkey_to_keyset(private_key)?;
-    let deposit_data =
-        DepositData::decrypt(data, key).map_err(|e| JsError::new(&format!("{}", e)))?;
-    Ok(deposit_data.into())
-}
-
-/// Decrypt the transfer data. This is also used to decrypt the withdrawal data.
-#[wasm_bindgen]
-pub async fn decrypt_transfer_data(
-    private_key: &str,
-    data: &[u8],
-) -> Result<JsTransferData, JsError> {
-    init_logger();
-    let key = str_privkey_to_keyset(private_key)?;
-    let transfer_data =
-        TransferData::decrypt(data, key).map_err(|e| JsError::new(&format!("{}", e)))?;
-    Ok(transfer_data.into())
-}
-
-/// Decrypt the tx data.
-#[wasm_bindgen]
-pub async fn decrypt_tx_data(private_key: &str, data: &[u8]) -> Result<JsTxData, JsError> {
-    init_logger();
-    let key = str_privkey_to_keyset(private_key)?;
-    let tx_data = TxData::decrypt(data, key).map_err(|e| JsError::new(&format!("{}", e)))?;
-    Ok(tx_data.into())
 }
 
 fn init_logger() {

--- a/wasm/src/native.rs
+++ b/wasm/src/native.rs
@@ -1,15 +1,21 @@
 use crate::{
+    client::{get_client, Config},
     init_logger,
     js_types::{
         auth::JsAuth,
         data::{JsDepositData, JsTransferData, JsTxData},
+        encrypted_data::JsEncryptedData,
     },
     utils::str_privkey_to_keyset,
 };
 use intmax2_client_sdk::external_api::store_vault_server::generate_auth_for_get_data_sequence;
-use intmax2_interfaces::data::{
-    deposit_data::DepositData, encryption::Encryption as _, transfer_data::TransferData,
-    tx_data::TxData,
+use intmax2_interfaces::{
+    api::store_vault_server::{interface::DataType, types::CursorOrder},
+    data::{
+        deposit_data::DepositData, encryption::Encryption as _, meta_data::MetaData,
+        transfer_data::TransferData, tx_data::TxData,
+    },
+    utils::signature::Auth,
 };
 use wasm_bindgen::{prelude::wasm_bindgen, JsError};
 
@@ -56,10 +62,65 @@ pub async fn generate_auth_for_store_vault(private_key: &str) -> Result<JsAuth, 
     Ok(auth.into())
 }
 
-// #[wasm_bindgen]
-// pub async fn fetch_encrypted_data(
-//     config: &Config,
-//     auth: &JsAuth,
-//     cursor: &Option<JsMetaData>,
-//     limit: &Option<u32>,
-// ) -> Result<JsEncryptedData, JsError> {
+#[wasm_bindgen]
+pub async fn fetch_encrypted_data(
+    config: &Config,
+    auth: &JsAuth,
+    timestamp: Option<u64>,
+    uuid: Option<String>,
+    limit: Option<u32>,
+    order: String, // asc or desc
+) -> Result<Vec<JsEncryptedData>, JsError> {
+    init_logger();
+    let client = get_client(config);
+    let sv = client.store_vault_server;
+    if (timestamp.is_none() && uuid.is_some()) || (timestamp.is_some() && uuid.is_none()) {
+        return Err(JsError::new(
+            "Either both timestamp and uuid should be provided or none",
+        ));
+    }
+    let auth: Auth = auth
+        .clone()
+        .try_into()
+        .map_err(|e| JsError::new(&format!("failed to convert JsAuth to Auth: {}", e)))?;
+    let order: CursorOrder = order
+        .parse()
+        .map_err(|e| JsError::new(&format!("failed to parse order: {}", e)))?;
+
+    let metadata_cursor = if let (Some(timestamp), Some(uuid)) = (timestamp, uuid) {
+        Some(MetaData { timestamp, uuid })
+    } else {
+        None
+    };
+    let mut data_array = Vec::new();
+    let (deposit_data, _) = sv
+        .get_data_sequence_native(DataType::Deposit, &metadata_cursor, &limit, &order, &auth)
+        .await?;
+    data_array.extend(
+        deposit_data
+            .into_iter()
+            .map(|data| JsEncryptedData::new(DataType::Deposit, data)),
+    );
+    let (transfer_data, _) = sv
+        .get_data_sequence_native(DataType::Transfer, &metadata_cursor, &limit, &order, &auth)
+        .await?;
+    data_array.extend(
+        transfer_data
+            .into_iter()
+            .map(|data| JsEncryptedData::new(DataType::Transfer, data)),
+    );
+    let (tx_data, _) = sv
+        .get_data_sequence_native(DataType::Tx, &metadata_cursor, &limit, &order, &auth)
+        .await?;
+    data_array.extend(
+        tx_data
+            .into_iter()
+            .map(|data| JsEncryptedData::new(DataType::Tx, data)),
+    );
+    data_array.sort_by_key(|data| (data.timestamp, data.uuid.clone()));
+    if order == CursorOrder::Desc {
+        data_array.reverse();
+    }
+    data_array.truncate(limit.unwrap_or(data_array.len() as u32) as usize);
+    Ok(data_array)
+}

--- a/wasm/src/native.rs
+++ b/wasm/src/native.rs
@@ -1,0 +1,65 @@
+use crate::{
+    init_logger,
+    js_types::{
+        auth::JsAuth,
+        data::{JsDepositData, JsTransferData, JsTxData},
+    },
+    utils::str_privkey_to_keyset,
+};
+use intmax2_client_sdk::external_api::store_vault_server::generate_auth_for_get_data_sequence;
+use intmax2_interfaces::data::{
+    deposit_data::DepositData, encryption::Encryption as _, transfer_data::TransferData,
+    tx_data::TxData,
+};
+use wasm_bindgen::{prelude::wasm_bindgen, JsError};
+
+/// Decrypt the deposit data.
+#[wasm_bindgen]
+pub async fn decrypt_deposit_data(
+    private_key: &str,
+    data: &[u8],
+) -> Result<JsDepositData, JsError> {
+    init_logger();
+    let key = str_privkey_to_keyset(private_key)?;
+    let deposit_data =
+        DepositData::decrypt(data, key).map_err(|e| JsError::new(&format!("{}", e)))?;
+    Ok(deposit_data.into())
+}
+
+/// Decrypt the transfer data. This is also used to decrypt the withdrawal data.
+#[wasm_bindgen]
+pub async fn decrypt_transfer_data(
+    private_key: &str,
+    data: &[u8],
+) -> Result<JsTransferData, JsError> {
+    init_logger();
+    let key = str_privkey_to_keyset(private_key)?;
+    let transfer_data =
+        TransferData::decrypt(data, key).map_err(|e| JsError::new(&format!("{}", e)))?;
+    Ok(transfer_data.into())
+}
+
+/// Decrypt the tx data.
+#[wasm_bindgen]
+pub async fn decrypt_tx_data(private_key: &str, data: &[u8]) -> Result<JsTxData, JsError> {
+    init_logger();
+    let key = str_privkey_to_keyset(private_key)?;
+    let tx_data = TxData::decrypt(data, key).map_err(|e| JsError::new(&format!("{}", e)))?;
+    Ok(tx_data.into())
+}
+
+#[wasm_bindgen]
+pub async fn generate_auth_for_store_vault(private_key: &str) -> Result<JsAuth, JsError> {
+    init_logger();
+    let key = str_privkey_to_keyset(private_key)?;
+    let auth = generate_auth_for_get_data_sequence(key);
+    Ok(auth.into())
+}
+
+// #[wasm_bindgen]
+// pub async fn fetch_encrypted_data(
+//     config: &Config,
+//     auth: &JsAuth,
+//     cursor: &Option<JsMetaData>,
+//     limit: &Option<u32>,
+// ) -> Result<JsEncryptedData, JsError> {


### PR DESCRIPTION
Refactored auth getter methods in store-vault-server/withdrawal-server to be reusable

This change enables the frontend to check for new data without using the private key each time.

Changes:
- store-vault-server
  * Modified get_data_sequence to support both ascending and descending order queries
  * Enhanced security by including method name in auth signature verification

- withdrawal-server
  * Added method name to auth signature verification

- wasm
  * Added new methods: generate_auth_for_store_vault and fetch_encrypted_data