### PR TITLE
initial max priority fee

### DIFF
--- a/block-builder/.env.example
+++ b/block-builder/.env.example
@@ -4,8 +4,10 @@ ETH_ALLOWANCE_FOR_BLOCK="0.3"
 ACCEPTING_TX_INTERVAL=40
 PROPOSING_BLOCK_INTERVAL=10
 DEPOSIT_CHECK_INTERVAL= 20 # if not set, the block builder does not check the deposit
+INITIAL_MAX_PRIORITY_FEE_PER_GAS="31337:500000000"
 
 ### For staging sepolia
+# ENV=staging
 # BLOCK_BUILDER_PRIVATE_KEY=
 # VALIDITY_PROVER_BASE_URL=https://stage.prover.intmax.io/v1/validity-prover
 # L2_RPC_URL="https://scroll-sepolia.g.alchemy.com/v2/<api-key>"
@@ -14,6 +16,7 @@ DEPOSIT_CHECK_INTERVAL= 20 # if not set, the block builder does not check the de
 # ROLLUP_CONTRACT_DEPLOYED_BLOCK_NUMBER=7525872
 
 ### For Local Development
+ENV=local
 BLOCK_BUILDER_PRIVATE_KEY=0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d # anvil key
 VALIDITY_PROVER_BASE_URL=http://localhost:9002
 L2_RPC_URL="http://127.0.0.1:8545"

--- a/client-sdk/src/external_api/contract/error.rs
+++ b/client-sdk/src/external_api/contract/error.rs
@@ -31,4 +31,7 @@ pub enum BlockchainError {
 
     #[error("Parse error: {0}")]
     ParseError(String),
+
+    #[error("Env error: {0}")]
+    EnvError(String),
 }


### PR DESCRIPTION
You can now configure the initial `max_priority_fee_per_gas` value per chain by setting the `INITIAL_MAX_PRIORITY_FEE_PER_GAS` environment variable using the format `chain_id:gas,...`

Example:
```bash
# Set initial max priority fee per gas for multiple chains
INITIAL_MAX_PRIORITY_FEE_PER_GAS="1:1000000000,137:30000000000"