### PR TITLE
Added `get-validity-pis` endpoint

### DIFF
--- a/interfaces/src/api/validity_prover/types.rs
+++ b/interfaces/src/api/validity_prover/types.rs
@@ -81,6 +81,12 @@ pub struct GetValidityWitnessResponse {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct GetValidityPisQuery {
+    pub block_number: u32,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct GetBlockMerkleProofQuery {
     pub root_block_number: u32,
     pub leaf_block_number: u32,


### PR DESCRIPTION
Added `validity-prover/get-validity-pis` to enable retrieving isValidBlock and related information through explore
