### PR TITLE
Added batch APIs to Validity Prover

### DIFF
--- a/.sqlx/query-cd02309fc23102581d80bf91fcaecab0ff5a132b0b44de88f6132dab96f433ed.json
+++ b/.sqlx/query-cd02309fc23102581d80bf91fcaecab0ff5a132b0b44de88f6132dab96f433ed.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT tx_tree_root, block_number \n            FROM tx_tree_roots \n            WHERE tx_tree_root = ANY($1)\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "tx_tree_root",
+        "type_info": "Bytea"
+      },
+      {
+        "ordinal": 1,
+        "name": "block_number",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "ByteaArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "cd02309fc23102581d80bf91fcaecab0ff5a132b0b44de88f6132dab96f433ed"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "balance-prover"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "actix-cors",
  "actix-web",
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "block-builder"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "actix-cors",
  "actix-web",
@@ -1335,7 +1335,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "dotenv",
  "envy",
@@ -3364,7 +3364,7 @@ dependencies = [
 
 [[package]]
 name = "intmax2-cli"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3397,7 +3397,7 @@ dependencies = [
 
 [[package]]
 name = "intmax2-client-sdk"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3448,7 +3448,7 @@ dependencies = [
 
 [[package]]
 name = "intmax2-interfaces"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "intmax2-wasm-lib"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5642,7 +5642,7 @@ dependencies = [
 
 [[package]]
 name = "server-common"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "actix-cors",
  "actix-web",
@@ -6081,7 +6081,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "store-vault-server"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "actix-cors",
  "actix-web",
@@ -6339,7 +6339,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "actix",
  "actix-cors",
@@ -7005,7 +7005,7 @@ dependencies = [
 
 [[package]]
 name = "validity-prover"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "actix-cors",
  "actix-web",
@@ -7040,7 +7040,7 @@ dependencies = [
 
 [[package]]
 name = "validity-prover-worker"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "actix-cors",
  "actix-web",
@@ -7531,7 +7531,7 @@ dependencies = [
 
 [[package]]
 name = "withdrawal-server"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "actix-cors",
  "actix-web",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3392,6 +3392,7 @@ dependencies = [
  "thiserror 2.0.11",
  "tokio",
  "url",
+ "uuid 1.12.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = ["job-servers/aggregator-prover"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 
 [workspace.dependencies]

--- a/client-sdk/src/client/strategy/deposit.rs
+++ b/client-sdk/src/client/strategy/deposit.rs
@@ -48,7 +48,10 @@ pub async fn fetch_deposit_info<S: StoreVaultClientInterface, V: ValidityProverC
         cursor,
     )
     .await?;
-    for (meta, deposit_data) in data_with_meta {
+
+    // First, collect all deposits that have valid token indices
+    let mut deposits_with_token_index = Vec::new();
+    for (meta, mut deposit_data) in data_with_meta {
         let token_index = liquidity_contract
             .get_token_index(
                 deposit_data.token_type,
@@ -56,32 +59,51 @@ pub async fn fetch_deposit_info<S: StoreVaultClientInterface, V: ValidityProverC
                 deposit_data.token_id,
             )
             .await?;
-        if token_index.is_none() {
-            log::error!("Token not found: {:?}", deposit_data);
-            // ignore this deposit
-            continue;
-        }
-        let mut deposit_data = deposit_data;
-        deposit_data.set_token_index(token_index.unwrap());
-        let deposit_hash = deposit_data.deposit_hash().unwrap();
-        if let Some(deposit_info) = validity_prover.get_deposit_info(deposit_hash).await? {
-            let meta = MetaDataWithBlockNumber {
-                meta,
-                block_number: deposit_info.block_number,
-            };
-            settled.push((meta, deposit_data));
-        } else if meta.timestamp + deposit_timeout < chrono::Utc::now().timestamp() as u64 {
-            // timeout
-            log::error!(
-                "Deposit uuid: {}, hash: {} is timeout",
-                meta.uuid,
-                deposit_hash
-            );
-            timeout.push((meta, deposit_data));
+        if let Some(index) = token_index {
+            deposit_data.set_token_index(index);
+            deposits_with_token_index.push((meta, deposit_data));
         } else {
-            // pending
-            log::info!("Deposit {} is pending", meta.uuid);
-            pending.push((meta, deposit_data));
+            log::error!("Token not found: {:?}", deposit_data);
+            // Skip deposits with invalid tokens
+        }
+    }
+
+    // Batch fetch deposit info for all valid deposits
+    let deposit_hashes: Vec<_> = deposits_with_token_index
+        .iter()
+        .map(|(_, deposit_data)| deposit_data.deposit_hash().unwrap()) // unwrap is safe because token index has been set.
+        .collect();
+    let deposit_infos = validity_prover
+        .get_deposit_info_batch(&deposit_hashes)
+        .await?;
+
+    // Process results and categorize deposits
+    for ((meta, deposit_data), deposit_info) in
+        deposits_with_token_index.into_iter().zip(deposit_infos)
+    {
+        match deposit_info {
+            Some(info) => {
+                // Deposit is settled
+                let meta = MetaDataWithBlockNumber {
+                    meta,
+                    block_number: info.block_number,
+                };
+                settled.push((meta, deposit_data));
+            }
+            None if meta.timestamp + deposit_timeout < chrono::Utc::now().timestamp() as u64 => {
+                // Deposit has timed out
+                log::error!(
+                    "Deposit uuid: {}, hash: {} is timeout",
+                    meta.uuid,
+                    deposit_data.deposit_hash().unwrap()
+                );
+                timeout.push((meta, deposit_data));
+            }
+            None => {
+                // Deposit is still pending
+                log::info!("Deposit {} is pending", meta.uuid);
+                pending.push((meta, deposit_data));
+            }
         }
     }
 

--- a/client-sdk/src/external_api/private_zkp_server.rs
+++ b/client-sdk/src/external_api/private_zkp_server.rs
@@ -299,7 +299,7 @@ impl PrivateZKPServerClient {
         let mut retries = 0;
         loop {
             let response = self.get_request(&request_id).await?;
-            log::info!("private_zkp_server status: {:?}", response.status);
+            log::info!("private_zkp_server status: {}", response.status);
             if response.status == "success" {
                 if response.result.is_none() {
                     return Err(ServerError::InvalidResponse(format!(

--- a/client-sdk/src/external_api/validity_prover.rs
+++ b/client-sdk/src/external_api/validity_prover.rs
@@ -4,12 +4,15 @@ use intmax2_interfaces::api::{
     validity_prover::{
         interface::{AccountInfo, DepositInfo, TransitionProofTask, ValidityProverClientInterface},
         types::{
-            AssignResponse, CompleteRequest, GetAccountInfoQuery, GetAccountInfoResponse,
-            GetBlockMerkleProofQuery, GetBlockMerkleProofResponse, GetBlockNumberByTxTreeRootQuery,
-            GetBlockNumberByTxTreeRootResponse, GetBlockNumberResponse, GetDepositInfoQuery,
-            GetDepositInfoResponse, GetDepositMerkleProofQuery, GetDepositMerkleProofResponse,
-            GetNextDepositIndexResponse, GetUpdateWitnessQuery, GetUpdateWitnessResponse,
-            GetValidityWitnessQuery, GetValidityWitnessResponse, HeartBeatRequest,
+            AssignResponse, CompleteRequest, GetAccountInfoBatchQuery, GetAccountInfoBatchResponse,
+            GetAccountInfoQuery, GetAccountInfoResponse, GetBlockMerkleProofQuery,
+            GetBlockMerkleProofResponse, GetBlockNumberByTxTreeRootBatchQuery,
+            GetBlockNumberByTxTreeRootBatchResponse, GetBlockNumberByTxTreeRootQuery,
+            GetBlockNumberByTxTreeRootResponse, GetBlockNumberResponse, GetDepositInfoBatchQuery,
+            GetDepositInfoBatchResponse, GetDepositInfoQuery, GetDepositInfoResponse,
+            GetDepositMerkleProofQuery, GetDepositMerkleProofResponse, GetNextDepositIndexResponse,
+            GetUpdateWitnessQuery, GetUpdateWitnessResponse, GetValidityWitnessQuery,
+            GetValidityWitnessResponse, HeartBeatRequest,
         },
     },
 };
@@ -110,6 +113,22 @@ impl ValidityProverClientInterface for ValidityProverClient {
         Ok(response.deposit_info)
     }
 
+    async fn get_deposit_info_batch(
+        &self,
+        deposit_hashes: &[Bytes32],
+    ) -> Result<Vec<Option<DepositInfo>>, ServerError> {
+        let query = GetDepositInfoBatchQuery {
+            deposit_hashes: deposit_hashes.to_vec(),
+        };
+        let response: GetDepositInfoBatchResponse = get_request(
+            &self.base_url,
+            "/validity-prover/get-deposit-info-batch",
+            Some(query),
+        )
+        .await?;
+        Ok(response.deposit_info)
+    }
+
     async fn get_block_number_by_tx_tree_root(
         &self,
         tx_tree_root: Bytes32,
@@ -122,6 +141,22 @@ impl ValidityProverClientInterface for ValidityProverClient {
         )
         .await?;
         Ok(response.block_number)
+    }
+
+    async fn get_block_number_by_tx_tree_root_batch(
+        &self,
+        tx_tree_roots: &[Bytes32],
+    ) -> Result<Vec<Option<u32>>, ServerError> {
+        let query = GetBlockNumberByTxTreeRootBatchQuery {
+            tx_tree_roots: tx_tree_roots.to_vec(),
+        };
+        let response: GetBlockNumberByTxTreeRootBatchResponse = get_request(
+            &self.base_url,
+            "/validity-prover/get-block-number-by-tx-tree-root-batch",
+            Some(query),
+        )
+        .await?;
+        Ok(response.block_numbers)
     }
 
     async fn get_validity_witness(
@@ -179,6 +214,22 @@ impl ValidityProverClientInterface for ValidityProverClient {
         let response: GetAccountInfoResponse = get_request(
             &self.base_url,
             "/validity-prover/get-account-info",
+            Some(query),
+        )
+        .await?;
+        Ok(response.account_info)
+    }
+
+    async fn get_account_info_batch(
+        &self,
+        pubkeys: &[U256],
+    ) -> Result<Vec<AccountInfo>, ServerError> {
+        let query = GetAccountInfoBatchQuery {
+            pubkeys: pubkeys.to_vec(),
+        };
+        let response: GetAccountInfoBatchResponse = get_request(
+            &self.base_url,
+            "/validity-prover/get-account-info-batch",
             Some(query),
         )
         .await?;

--- a/client-sdk/src/external_api/validity_prover.rs
+++ b/client-sdk/src/external_api/validity_prover.rs
@@ -4,15 +4,16 @@ use intmax2_interfaces::api::{
     validity_prover::{
         interface::{AccountInfo, DepositInfo, TransitionProofTask, ValidityProverClientInterface},
         types::{
-            AssignResponse, CompleteRequest, GetAccountInfoBatchQuery, GetAccountInfoBatchResponse,
-            GetAccountInfoQuery, GetAccountInfoResponse, GetBlockMerkleProofQuery,
-            GetBlockMerkleProofResponse, GetBlockNumberByTxTreeRootBatchQuery,
-            GetBlockNumberByTxTreeRootBatchResponse, GetBlockNumberByTxTreeRootQuery,
-            GetBlockNumberByTxTreeRootResponse, GetBlockNumberResponse, GetDepositInfoBatchQuery,
-            GetDepositInfoBatchResponse, GetDepositInfoQuery, GetDepositInfoResponse,
-            GetDepositMerkleProofQuery, GetDepositMerkleProofResponse, GetNextDepositIndexResponse,
-            GetUpdateWitnessQuery, GetUpdateWitnessResponse, GetValidityWitnessQuery,
-            GetValidityWitnessResponse, HeartBeatRequest,
+            AssignResponse, CompleteRequest, GetAccountInfoBatchRequest,
+            GetAccountInfoBatchResponse, GetAccountInfoQuery, GetAccountInfoResponse,
+            GetBlockMerkleProofQuery, GetBlockMerkleProofResponse,
+            GetBlockNumberByTxTreeRootBatchRequest, GetBlockNumberByTxTreeRootBatchResponse,
+            GetBlockNumberByTxTreeRootQuery, GetBlockNumberByTxTreeRootResponse,
+            GetBlockNumberResponse, GetDepositInfoBatchRequest, GetDepositInfoBatchResponse,
+            GetDepositInfoQuery, GetDepositInfoResponse, GetDepositMerkleProofQuery,
+            GetDepositMerkleProofResponse, GetNextDepositIndexResponse, GetUpdateWitnessQuery,
+            GetUpdateWitnessResponse, GetValidityWitnessQuery, GetValidityWitnessResponse,
+            HeartBeatRequest,
         },
     },
 };
@@ -117,13 +118,13 @@ impl ValidityProverClientInterface for ValidityProverClient {
         &self,
         deposit_hashes: &[Bytes32],
     ) -> Result<Vec<Option<DepositInfo>>, ServerError> {
-        let query = GetDepositInfoBatchQuery {
+        let request = GetDepositInfoBatchRequest {
             deposit_hashes: deposit_hashes.to_vec(),
         };
-        let response: GetDepositInfoBatchResponse = get_request(
+        let response: GetDepositInfoBatchResponse = post_request(
             &self.base_url,
             "/validity-prover/get-deposit-info-batch",
-            Some(query),
+            Some(&request),
         )
         .await?;
         Ok(response.deposit_info)
@@ -147,13 +148,13 @@ impl ValidityProverClientInterface for ValidityProverClient {
         &self,
         tx_tree_roots: &[Bytes32],
     ) -> Result<Vec<Option<u32>>, ServerError> {
-        let query = GetBlockNumberByTxTreeRootBatchQuery {
+        let request = GetBlockNumberByTxTreeRootBatchRequest {
             tx_tree_roots: tx_tree_roots.to_vec(),
         };
-        let response: GetBlockNumberByTxTreeRootBatchResponse = get_request(
+        let response: GetBlockNumberByTxTreeRootBatchResponse = post_request(
             &self.base_url,
             "/validity-prover/get-block-number-by-tx-tree-root-batch",
-            Some(query),
+            Some(&request),
         )
         .await?;
         Ok(response.block_numbers)
@@ -224,13 +225,13 @@ impl ValidityProverClientInterface for ValidityProverClient {
         &self,
         pubkeys: &[U256],
     ) -> Result<Vec<AccountInfo>, ServerError> {
-        let query = GetAccountInfoBatchQuery {
+        let request = GetAccountInfoBatchRequest {
             pubkeys: pubkeys.to_vec(),
         };
-        let response: GetAccountInfoBatchResponse = get_request(
+        let response: GetAccountInfoBatchResponse = post_request(
             &self.base_url,
             "/validity-prover/get-account-info-batch",
-            Some(query),
+            Some(&request),
         )
         .await?;
         Ok(response.account_info)

--- a/interfaces/src/api/validity_prover/interface.rs
+++ b/interfaces/src/api/validity_prover/interface.rs
@@ -16,6 +16,8 @@ type F = GoldilocksField;
 type C = PoseidonGoldilocksConfig;
 const D: usize = 2;
 
+pub const MAX_BATCH_SIZE: usize = 128;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DepositInfo {

--- a/interfaces/src/api/validity_prover/interface.rs
+++ b/interfaces/src/api/validity_prover/interface.rs
@@ -61,10 +61,20 @@ pub trait ValidityProverClientInterface {
         deposit_hash: Bytes32,
     ) -> Result<Option<DepositInfo>, ServerError>;
 
+    async fn get_deposit_info_batch(
+        &self,
+        deposit_hashes: &[Bytes32],
+    ) -> Result<Vec<Option<DepositInfo>>, ServerError>;
+
     async fn get_block_number_by_tx_tree_root(
         &self,
         tx_tree_root: Bytes32,
     ) -> Result<Option<u32>, ServerError>;
+
+    async fn get_block_number_by_tx_tree_root_batch(
+        &self,
+        tx_tree_roots: &[Bytes32],
+    ) -> Result<Vec<Option<u32>>, ServerError>;
 
     async fn get_validity_witness(&self, block_number: u32)
         -> Result<ValidityWitness, ServerError>;
@@ -82,4 +92,9 @@ pub trait ValidityProverClientInterface {
     ) -> Result<DepositMerkleProof, ServerError>;
 
     async fn get_account_info(&self, pubkey: U256) -> Result<AccountInfo, ServerError>;
+
+    async fn get_account_info_batch(
+        &self,
+        pubkeys: &[U256],
+    ) -> Result<Vec<AccountInfo>, ServerError>;
 }

--- a/interfaces/src/api/validity_prover/types.rs
+++ b/interfaces/src/api/validity_prover/types.rs
@@ -57,6 +57,18 @@ pub struct GetDepositInfoResponse {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct GetDepositInfoBatchQuery {
+    pub deposit_hashes: Vec<Bytes32>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetDepositInfoBatchResponse {
+    pub deposit_info: Vec<Option<DepositInfo>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct GetBlockNumberByTxTreeRootQuery {
     pub tx_tree_root: Bytes32,
 }
@@ -65,6 +77,18 @@ pub struct GetBlockNumberByTxTreeRootQuery {
 #[serde(rename_all = "camelCase")]
 pub struct GetBlockNumberByTxTreeRootResponse {
     pub block_number: Option<u32>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetBlockNumberByTxTreeRootBatchQuery {
+    pub tx_tree_roots: Vec<Bytes32>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetBlockNumberByTxTreeRootBatchResponse {
+    pub block_numbers: Vec<Option<u32>>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -121,6 +145,18 @@ pub struct GetAccountInfoQuery {
 #[serde(rename_all = "camelCase")]
 pub struct GetAccountInfoResponse {
     pub account_info: AccountInfo,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetAccountInfoBatchQuery {
+    pub pubkeys: Vec<U256>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetAccountInfoBatchResponse {
+    pub account_info: Vec<AccountInfo>,
 }
 
 // Below are Coordinator API

--- a/interfaces/src/api/validity_prover/types.rs
+++ b/interfaces/src/api/validity_prover/types.rs
@@ -57,7 +57,7 @@ pub struct GetDepositInfoResponse {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct GetDepositInfoBatchQuery {
+pub struct GetDepositInfoBatchRequest {
     pub deposit_hashes: Vec<Bytes32>,
 }
 
@@ -81,7 +81,7 @@ pub struct GetBlockNumberByTxTreeRootResponse {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct GetBlockNumberByTxTreeRootBatchQuery {
+pub struct GetBlockNumberByTxTreeRootBatchRequest {
     pub tx_tree_roots: Vec<Bytes32>,
 }
 
@@ -149,7 +149,7 @@ pub struct GetAccountInfoResponse {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct GetAccountInfoBatchQuery {
+pub struct GetAccountInfoBatchRequest {
     pub pubkeys: Vec<U256>,
 }
 

--- a/validity-prover/src/api/witness_generator.rs
+++ b/validity-prover/src/api/witness_generator.rs
@@ -4,20 +4,21 @@ use actix_web::{
     web::{Data, Json},
     Error,
 };
-use intmax2_interfaces::api::validity_prover::types::{
-    GetAccountInfoBatchRequest, GetAccountInfoBatchResponse, GetAccountInfoQuery,
-    GetAccountInfoResponse, GetBlockMerkleProofQuery, GetBlockMerkleProofResponse,
-    GetBlockNumberByTxTreeRootBatchRequest, GetBlockNumberByTxTreeRootBatchResponse,
-    GetBlockNumberByTxTreeRootQuery, GetBlockNumberByTxTreeRootResponse, GetBlockNumberResponse,
-    GetDepositInfoBatchRequest, GetDepositInfoBatchResponse, GetDepositInfoQuery,
-    GetDepositInfoResponse, GetDepositMerkleProofQuery, GetDepositMerkleProofResponse,
-    GetNextDepositIndexResponse, GetUpdateWitnessQuery, GetUpdateWitnessResponse,
-    GetValidityWitnessQuery, GetValidityWitnessResponse,
+use intmax2_interfaces::api::validity_prover::{
+    interface::MAX_BATCH_SIZE,
+    types::{
+        GetAccountInfoBatchRequest, GetAccountInfoBatchResponse, GetAccountInfoQuery,
+        GetAccountInfoResponse, GetBlockMerkleProofQuery, GetBlockMerkleProofResponse,
+        GetBlockNumberByTxTreeRootBatchRequest, GetBlockNumberByTxTreeRootBatchResponse,
+        GetBlockNumberByTxTreeRootQuery, GetBlockNumberByTxTreeRootResponse,
+        GetBlockNumberResponse, GetDepositInfoBatchRequest, GetDepositInfoBatchResponse,
+        GetDepositInfoQuery, GetDepositInfoResponse, GetDepositMerkleProofQuery,
+        GetDepositMerkleProofResponse, GetNextDepositIndexResponse, GetUpdateWitnessQuery,
+        GetUpdateWitnessResponse, GetValidityWitnessQuery, GetValidityWitnessResponse,
+    },
 };
 use intmax2_zkp::circuits::validity::validity_pis::ValidityPublicInputs;
 use serde_qs::actix::QsQuery;
-
-const MAX_BATCH_SIZE: usize = 1024;
 
 #[get("/block-number")]
 pub async fn get_block_number(state: Data<State>) -> Result<Json<GetBlockNumberResponse>, Error> {

--- a/validity-prover/src/api/witness_generator.rs
+++ b/validity-prover/src/api/witness_generator.rs
@@ -1,15 +1,15 @@
 use crate::api::state::State;
 use actix_web::{
-    get,
+    get, post,
     web::{Data, Json},
     Error,
 };
 use intmax2_interfaces::api::validity_prover::types::{
-    GetAccountInfoBatchQuery, GetAccountInfoBatchResponse, GetAccountInfoQuery,
+    GetAccountInfoBatchRequest, GetAccountInfoBatchResponse, GetAccountInfoQuery,
     GetAccountInfoResponse, GetBlockMerkleProofQuery, GetBlockMerkleProofResponse,
-    GetBlockNumberByTxTreeRootBatchQuery, GetBlockNumberByTxTreeRootBatchResponse,
+    GetBlockNumberByTxTreeRootBatchRequest, GetBlockNumberByTxTreeRootBatchResponse,
     GetBlockNumberByTxTreeRootQuery, GetBlockNumberByTxTreeRootResponse, GetBlockNumberResponse,
-    GetDepositInfoBatchQuery, GetDepositInfoBatchResponse, GetDepositInfoQuery,
+    GetDepositInfoBatchRequest, GetDepositInfoBatchResponse, GetDepositInfoQuery,
     GetDepositInfoResponse, GetDepositMerkleProofQuery, GetDepositMerkleProofResponse,
     GetNextDepositIndexResponse, GetUpdateWitnessQuery, GetUpdateWitnessResponse,
     GetValidityWitnessQuery, GetValidityWitnessResponse,
@@ -65,15 +65,15 @@ pub async fn get_account_info(
     Ok(Json(GetAccountInfoResponse { account_info }))
 }
 
-#[get("/get-account-info-batch")]
+#[post("/get-account-info-batch")]
 pub async fn get_account_info_batch(
     state: Data<State>,
-    query: QsQuery<GetAccountInfoBatchQuery>,
+    request: Json<GetAccountInfoBatchRequest>,
 ) -> Result<Json<GetAccountInfoBatchResponse>, Error> {
-    let query = query.into_inner();
+    let request = request.into_inner();
     let account_info = state
         .witness_generator
-        .get_account_info_batch(&query.pubkeys)
+        .get_account_info_batch(&request.pubkeys)
         .await
         .map_err(actix_web::error::ErrorInternalServerError)?;
     Ok(Json(GetAccountInfoBatchResponse { account_info }))
@@ -140,15 +140,15 @@ pub async fn get_deposit_info(
     Ok(Json(GetDepositInfoResponse { deposit_info }))
 }
 
-#[get("/get-deposit-info-batch")]
+#[post("/get-deposit-info-batch")]
 pub async fn get_deposit_info_batch(
     state: Data<State>,
-    query: QsQuery<GetDepositInfoBatchQuery>,
+    request: Json<GetDepositInfoBatchRequest>,
 ) -> Result<Json<GetDepositInfoBatchResponse>, Error> {
-    let query = query.into_inner();
+    let request = request.into_inner();
     let deposit_info = state
         .witness_generator
-        .get_deposit_info_batch(&query.deposit_hashes)
+        .get_deposit_info_batch(&request.deposit_hashes)
         .await
         .map_err(actix_web::error::ErrorInternalServerError)?;
     Ok(Json(GetDepositInfoBatchResponse { deposit_info }))
@@ -168,15 +168,15 @@ pub async fn get_block_number_by_tx_tree_root(
     Ok(Json(GetBlockNumberByTxTreeRootResponse { block_number }))
 }
 
-#[get("/get-block-number-by-tx-tree-root-batch")]
+#[post("/get-block-number-by-tx-tree-root-batch")]
 pub async fn get_block_number_by_tx_tree_root_batch(
     state: Data<State>,
-    query: QsQuery<GetBlockNumberByTxTreeRootBatchQuery>,
+    request: Json<GetBlockNumberByTxTreeRootBatchRequest>,
 ) -> Result<Json<GetBlockNumberByTxTreeRootBatchResponse>, Error> {
-    let query = query.into_inner();
+    let request = request.into_inner();
     let block_numbers = state
         .witness_generator
-        .get_block_number_by_tx_tree_root_batch(&query.tx_tree_roots)
+        .get_block_number_by_tx_tree_root_batch(&request.tx_tree_roots)
         .await
         .map_err(actix_web::error::ErrorInternalServerError)?;
     Ok(Json(GetBlockNumberByTxTreeRootBatchResponse {

--- a/validity-prover/src/api/witness_generator.rs
+++ b/validity-prover/src/api/witness_generator.rs
@@ -17,6 +17,8 @@ use intmax2_interfaces::api::validity_prover::types::{
 use intmax2_zkp::circuits::validity::validity_pis::ValidityPublicInputs;
 use serde_qs::actix::QsQuery;
 
+const MAX_BATCH_SIZE: usize = 1024;
+
 #[get("/block-number")]
 pub async fn get_block_number(state: Data<State>) -> Result<Json<GetBlockNumberResponse>, Error> {
     let block_number = state
@@ -71,6 +73,9 @@ pub async fn get_account_info_batch(
     request: Json<GetAccountInfoBatchRequest>,
 ) -> Result<Json<GetAccountInfoBatchResponse>, Error> {
     let request = request.into_inner();
+    if request.pubkeys.len() > MAX_BATCH_SIZE {
+        return Err(actix_web::error::ErrorBadRequest("Batch size is too large"));
+    }
     let account_info = state
         .witness_generator
         .get_account_info_batch(&request.pubkeys)
@@ -146,6 +151,9 @@ pub async fn get_deposit_info_batch(
     request: Json<GetDepositInfoBatchRequest>,
 ) -> Result<Json<GetDepositInfoBatchResponse>, Error> {
     let request = request.into_inner();
+    if request.deposit_hashes.len() > MAX_BATCH_SIZE {
+        return Err(actix_web::error::ErrorBadRequest("Batch size is too large"));
+    }
     let deposit_info = state
         .witness_generator
         .get_deposit_info_batch(&request.deposit_hashes)
@@ -174,6 +182,9 @@ pub async fn get_block_number_by_tx_tree_root_batch(
     request: Json<GetBlockNumberByTxTreeRootBatchRequest>,
 ) -> Result<Json<GetBlockNumberByTxTreeRootBatchResponse>, Error> {
     let request = request.into_inner();
+    if request.tx_tree_roots.len() > MAX_BATCH_SIZE {
+        return Err(actix_web::error::ErrorBadRequest("Batch size is too large"));
+    }
     let block_numbers = state
         .witness_generator
         .get_block_number_by_tx_tree_root_batch(&request.tx_tree_roots)

--- a/validity-prover/src/app/witness_generator.rs
+++ b/validity-prover/src/app/witness_generator.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -334,6 +335,18 @@ impl WitnessGenerator {
         Ok(deposit_info)
     }
 
+    pub async fn get_deposit_info_batch(
+        &self,
+        deposit_hashes: &[Bytes32],
+    ) -> Result<Vec<Option<DepositInfo>>, ValidityProverError> {
+        let mut deposit_infos = Vec::new();
+        for deposit_hash in deposit_hashes {
+            let deposit_info = self.observer.get_deposit_info(*deposit_hash).await?;
+            deposit_infos.push(deposit_info);
+        }
+        Ok(deposit_infos)
+    }
+
     pub async fn get_block_number_by_tx_tree_root(
         &self,
         tx_tree_root: Bytes32,
@@ -346,6 +359,43 @@ impl WitnessGenerator {
         .await?;
 
         Ok(record.map(|r| r.block_number as u32))
+    }
+
+    pub async fn get_block_number_by_tx_tree_root_batch(
+        &self,
+        tx_tree_roots: Vec<Bytes32>,
+    ) -> Result<Vec<Option<u32>>, ValidityProverError> {
+        // early return
+        if tx_tree_roots.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let root_bytes: Vec<Vec<u8>> = tx_tree_roots.iter().map(|r| r.to_bytes_be()).collect();
+
+        let records = sqlx::query!(
+            r#"
+            SELECT tx_tree_root, block_number 
+            FROM tx_tree_roots 
+            WHERE tx_tree_root = ANY($1)
+            "#,
+            &root_bytes as &[Vec<u8>]
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        let block_map: HashMap<Vec<u8>, i32> = records
+            .into_iter()
+            .map(|r| (r.tx_tree_root, r.block_number))
+            .collect();
+
+        Ok(tx_tree_roots
+            .iter()
+            .map(|root| {
+                block_map
+                    .get(&root.to_bytes_be())
+                    .map(|&block_number| block_number as u32)
+            })
+            .collect())
     }
 
     pub async fn get_validity_witness(

--- a/validity-prover/src/app/witness_generator.rs
+++ b/validity-prover/src/app/witness_generator.rs
@@ -327,6 +327,18 @@ impl WitnessGenerator {
         })
     }
 
+    pub async fn get_account_info_batch(
+        &self,
+        pubkeys: &[U256],
+    ) -> Result<Vec<AccountInfo>, ValidityProverError> {
+        let mut account_infos = Vec::new();
+        for pubkey in pubkeys {
+            let account_info = self.get_account_info(*pubkey).await?;
+            account_infos.push(account_info);
+        }
+        Ok(account_infos)
+    }
+
     pub async fn get_deposit_info(
         &self,
         deposit_hash: Bytes32,
@@ -363,7 +375,7 @@ impl WitnessGenerator {
 
     pub async fn get_block_number_by_tx_tree_root_batch(
         &self,
-        tx_tree_roots: Vec<Bytes32>,
+        tx_tree_roots: &[Bytes32],
     ) -> Result<Vec<Option<u32>>, ValidityProverError> {
         // early return
         if tx_tree_roots.is_empty() {


### PR DESCRIPTION
Introduced new batch APIs to the Validity Prover and replaced multiple single queries with batched operations to improve performance and reduce the number of API calls.

## Changes
### Added new batch APIs to Validity Prover:
- `get_deposit_info_batch`
- `get_account_info_batch`
- `get_block_number_by_tx_tree_root_batch`

### Replaced existing queries with batch operations in:
- Client's fetch history functionality
- Client's strategy determination process
- Block builder's post block queries