### PR TITLE
Introduces batch size limitations to store-vault-server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "balance-prover"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "actix-cors",
  "actix-web",
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "block-builder"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "actix-cors",
  "actix-web",
@@ -1335,7 +1335,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "dotenv",
  "envy",
@@ -3364,7 +3364,7 @@ dependencies = [
 
 [[package]]
 name = "intmax2-cli"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3397,7 +3397,7 @@ dependencies = [
 
 [[package]]
 name = "intmax2-client-sdk"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3448,7 +3448,7 @@ dependencies = [
 
 [[package]]
 name = "intmax2-interfaces"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "intmax2-wasm-lib"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5642,7 +5642,7 @@ dependencies = [
 
 [[package]]
 name = "server-common"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "actix-cors",
  "actix-web",
@@ -6081,7 +6081,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "store-vault-server"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "actix-cors",
  "actix-web",
@@ -6339,7 +6339,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "actix",
  "actix-cors",
@@ -7005,7 +7005,7 @@ dependencies = [
 
 [[package]]
 name = "validity-prover"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "actix-cors",
  "actix-web",
@@ -7040,7 +7040,7 @@ dependencies = [
 
 [[package]]
 name = "validity-prover-worker"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "actix-cors",
  "actix-web",
@@ -7531,7 +7531,7 @@ dependencies = [
 
 [[package]]
 name = "withdrawal-server"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "actix-cors",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = ["job-servers/aggregator-prover"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 
 [workspace.dependencies]

--- a/interfaces/src/api/error.rs
+++ b/interfaces/src/api/error.rs
@@ -27,6 +27,9 @@ pub enum ServerError {
     #[error("Proof verification error: {0}")]
     ProofVerificationError(String),
 
+    #[error("Invalid request: {0}")]
+    InvalidRequest(String),
+
     #[error("Invalid response: {0}")]
     InvalidResponse(String),
 

--- a/interfaces/src/api/store_vault_server/interface.rs
+++ b/interfaces/src/api/store_vault_server/interface.rs
@@ -12,6 +12,8 @@ use crate::api::error::ServerError;
 
 use super::types::{DataWithMetaData, MetaDataCursor, MetaDataCursorResponse};
 
+pub const MAX_BATCH_SIZE: usize = 256;
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "camelCase")]
 pub enum DataType {

--- a/store-vault-server/.env.example
+++ b/store-vault-server/.env.example
@@ -3,4 +3,3 @@ PORT=9000
 DATABASE_URL="postgres://postgres:password@localhost/store_vault_server"
 DATABASE_MAX_CONNECTIONS=10
 DATABASE_TIMEOUT=10 # seconds
-MAX_PAGINATION_LIMIT=100

--- a/store-vault-server/src/lib.rs
+++ b/store-vault-server/src/lib.rs
@@ -9,5 +9,4 @@ pub struct EnvVar {
     pub database_url: String,
     pub database_max_connections: u32,
     pub database_timeout: u64,
-    pub max_pagination_limit: u32,
 }


### PR DESCRIPTION
Introduces batch size limitations and automatic chunking mechanism to improve system stability.

**Key changes:**

- Set `MAX_BATCH_SIZE` constant to `256` items
- Added automatic request chunking in client SDK
- Implemented batch size validation across endpoints
- Removed redundant `max_pagination_limit` config
- Bumped version from` 0.1.12` to `0.1.13`