### PR TITLE
remove: db index for validity-prover's leaves table

### DIFF
--- a/validity-prover/migrations/20250307095617_del_index_for_leaves.down.sql
+++ b/validity-prover/migrations/20250307095617_del_index_for_leaves.down.sql
@@ -1,0 +1,2 @@
+CREATE INDEX idx_leaves_lookup ON public.leaves USING btree ("position", tag, timestamp_value DESC);
+CREATE INDEX idx_leaves_timestamp ON public.leaves USING btree (timestamp_value DESC, tag);

--- a/validity-prover/migrations/20250307095617_del_index_for_leaves.up.sql
+++ b/validity-prover/migrations/20250307095617_del_index_for_leaves.up.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_leaves_lookup;
+DROP INDEX IF EXISTS idx_leaves_timestamp;


### PR DESCRIPTION
## Change Summary:
This PR adds migration scripts to remove two indexes ( `idx_leaves_lookup` and `idx_leaves_timestamp` ) from the leaves table. These indexes are not being effectively utilized in our current query patterns and are being removed to improve database performance.