### PR TITLE
Perf hash nodes

### DIFF
--- a/.sqlx/query-5d8aa4b3337528381f508ce98fee9fae04337bc51c427972bb91aef4efa526e7.json
+++ b/.sqlx/query-5d8aa4b3337528381f508ce98fee9fae04337bc51c427972bb91aef4efa526e7.json
@@ -1,0 +1,30 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT bit_path, hash_value\n            FROM hash_nodes\n            WHERE bit_path = ANY($1)\n              AND timestamp_value <= $2\n              AND tag = $3\n            ORDER BY bit_path, timestamp_value DESC\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "bit_path",
+        "type_info": "Bytea"
+      },
+      {
+        "ordinal": 1,
+        "name": "hash_value",
+        "type_info": "Bytea"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "ByteaArray",
+        "Int8",
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "5d8aa4b3337528381f508ce98fee9fae04337bc51c427972bb91aef4efa526e7"
+}

--- a/validity-prover/src/trees/merkle_tree/mod.rs
+++ b/validity-prover/src/trees/merkle_tree/mod.rs
@@ -177,6 +177,34 @@ mod tests {
 
     #[tokio::test]
     #[ignore]
+    async fn test_speed_incremental_merkle_tree_prove() -> anyhow::Result<()> {
+        let height = 32;
+        let n = 5000;
+        let mut rng = rand::thread_rng();
+
+        let database_url = setup_test();
+        let pool = sqlx::Pool::connect(&database_url).await?;
+
+        let tree = SqlIncrementalMerkleTree::<V>::new(pool, rng.gen(), height);
+        tree.reset(0).await?;
+
+        let time = std::time::Instant::now();
+        for i in 0..n {
+            let timestamp = i;
+            tree.prove(timestamp, i).await?;
+        }
+        println!(
+            "SqlIncrementMerkleTree.prove: {} times, {} height, {} seconds",
+            n,
+            height,
+            time.elapsed().as_secs_f64()
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[ignore]
     async fn test_speed_incremental_merkle_tree_reset() -> anyhow::Result<()> {
         let height = 32;
         let n = 1000;

--- a/validity-prover/src/trees/merkle_tree/sql_node_hash.rs
+++ b/validity-prover/src/trees/merkle_tree/sql_node_hash.rs
@@ -167,3 +167,369 @@ impl<V: Leafable + Serialize + DeserializeOwned> SqlNodeHashes<V> {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use rand::Rng;
+    use sqlx::postgres::PgPoolOptions;
+
+    use super::{BitPath, SqlNodeHashes};
+    use crate::trees::utils::bit_path::BitPath as BitPathOrig;
+    use intmax2_zkp::utils::leafable::Leafable;
+
+    type TestValue = u32;
+
+    fn setup_test() -> String {
+        dotenv::dotenv().ok();
+        std::env::var("DATABASE_URL").unwrap()
+    }
+
+    // helper func
+    fn collect_paths(path: &BitPath) -> Vec<BitPath> {
+        let mut paths = vec![];
+        let mut current_path = *path;
+        while !current_path.is_empty() {
+            paths.push(current_path);
+            current_path.pop();
+        }
+        paths
+    }
+
+    #[tokio::test]
+    async fn test_prove_empty_tree() -> anyhow::Result<()> {
+        let database_url = setup_test();
+        let pool = PgPoolOptions::new()
+            .max_connections(5)
+            .connect(&database_url)
+            .await?;
+
+        let mut rng = rand::thread_rng();
+        let tag = rng.gen();
+        let height = 10;
+        let node_hashes = SqlNodeHashes::<TestValue>::new(pool.clone(), tag, height);
+
+        let timestamp = 1000;
+        let mut tx = pool.begin().await?;
+
+        for index in [0, 1, 5, 10, 100] {
+            let proof = node_hashes.prove(&mut tx, timestamp, index).await?;
+
+            let expected_length = height;
+            assert_eq!(
+                proof.siblings.len(),
+                expected_length,
+                "Proof for index {} should have {} siblings",
+                index,
+                expected_length
+            );
+
+            let mut path = BitPath::new(height as u32, index);
+            path.reverse();
+            let paths = collect_paths(&path);
+
+            for (i, sibling) in proof.siblings.iter().enumerate() {
+                let sibling_path = paths[i].sibling();
+                let expected_zero_hash = node_hashes.zero_hashes[sibling_path.len() as usize];
+                assert_eq!(
+                    *sibling, expected_zero_hash,
+                    "Sibling hash at position {} for index {} should be zero hash",
+                    i, index
+                );
+            }
+        }
+
+        tx.rollback().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_prove_sequential_entries() -> anyhow::Result<()> {
+        let database_url = setup_test();
+        let pool = PgPoolOptions::new()
+            .max_connections(5)
+            .connect(&database_url)
+            .await?;
+
+        let mut rng = rand::thread_rng();
+        let tag = rng.gen();
+        let height = 10;
+        let node_hashes = SqlNodeHashes::<TestValue>::new(pool.clone(), tag, height);
+
+        let timestamp = 1000;
+        let mut tx = pool.begin().await?;
+
+        let num_entries = 16;
+        let mut expected_hashes = Vec::new();
+
+        for i in 0..num_entries {
+            let bit_path = BitPathOrig::new(height as u32, i);
+            let hash_value = TestValue::empty_leaf().hash();
+            expected_hashes.push((bit_path, hash_value)); // store expected values
+            node_hashes
+                .save_node(&mut tx, timestamp, bit_path, hash_value)
+                .await?;
+        }
+
+        for index in 0..num_entries {
+            let proof = node_hashes.prove(&mut tx, timestamp, index).await?;
+
+            let mut path = BitPath::new(height as u32, index);
+            path.reverse();
+            let paths = collect_paths(&path);
+
+            assert_eq!(
+                proof.siblings.len(),
+                height,
+                "Proof for index {} should have {} siblings",
+                index,
+                height
+            );
+
+            for (i, sibling) in proof.siblings.iter().enumerate() {
+                let sibling_path = paths[i].sibling();
+
+                let sibling_index = sibling_path.value();
+                if sibling_index >= num_entries && i > height - 4 {
+                    let expected_zero_hash = node_hashes.zero_hashes[sibling_path.len() as usize];
+                    assert_eq!(
+                        *sibling, expected_zero_hash,
+                        "Sibling hash at position {} for index {} should be zero hash",
+                        i, index
+                    );
+                }
+            }
+        }
+
+        tx.rollback().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_prove_sparse_entries() -> anyhow::Result<()> {
+        let database_url = setup_test();
+        let pool = PgPoolOptions::new()
+            .max_connections(5)
+            .connect(&database_url)
+            .await?;
+
+        let mut rng = rand::thread_rng();
+        let tag = rng.gen();
+        let height = 10;
+        let node_hashes = SqlNodeHashes::<TestValue>::new(pool.clone(), tag, height);
+
+        let timestamp = 1000;
+        let mut tx = pool.begin().await?;
+
+        let sparse_indices = [100, 200, 500, 1000];
+        let hash_value = TestValue::empty_leaf().hash();
+
+        for &i in &sparse_indices {
+            let bit_path = BitPathOrig::new(height as u32, i);
+            node_hashes
+                .save_node(&mut tx, timestamp, bit_path, hash_value)
+                .await?;
+        }
+
+        for &index in &sparse_indices {
+            let proof = node_hashes.prove(&mut tx, timestamp, index).await?;
+            let expected_length = height;
+            assert_eq!(
+                proof.siblings.len(),
+                expected_length,
+                "Proof for sparse index {} should have {} siblings",
+                index,
+                expected_length
+            );
+        }
+
+        tx.rollback().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_prove_boundary_indices() -> anyhow::Result<()> {
+        let database_url = setup_test();
+        let pool = PgPoolOptions::new()
+            .max_connections(5)
+            .connect(&database_url)
+            .await?;
+
+        let mut rng = rand::thread_rng();
+        let tag = rng.gen();
+        let height = 10;
+        let node_hashes = SqlNodeHashes::<TestValue>::new(pool.clone(), tag, height);
+
+        let timestamp = 1000;
+        let mut tx = pool.begin().await?;
+
+        let boundary_indices = [0, (1 << height) - 1, (1 << (height - 1))];
+        let hash_value = TestValue::empty_leaf().hash();
+
+        for &i in &boundary_indices {
+            let bit_path = BitPathOrig::new(height as u32, i);
+            node_hashes
+                .save_node(&mut tx, timestamp, bit_path, hash_value)
+                .await?;
+        }
+
+        for &index in &boundary_indices {
+            let proof = node_hashes.prove(&mut tx, timestamp, index).await?;
+
+            let expected_length = height;
+            assert_eq!(
+                proof.siblings.len(),
+                expected_length,
+                "Proof for boundary index {} should have {} siblings",
+                index,
+                expected_length
+            );
+        }
+
+        tx.rollback().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_prove_timestamps() -> anyhow::Result<()> {
+        let database_url = setup_test();
+        let pool = PgPoolOptions::new()
+            .max_connections(5)
+            .connect(&database_url)
+            .await?;
+
+        let mut rng = rand::thread_rng();
+        let tag = rng.gen();
+        let height = 10;
+        let node_hashes = SqlNodeHashes::<TestValue>::new(pool.clone(), tag, height);
+
+        let mut tx = pool.begin().await?;
+
+        let timestamps = [500, 800, 1200];
+        let test_index = 42;
+        let hash_value = TestValue::empty_leaf().hash();
+
+        for &ts in &timestamps {
+            let bit_path = BitPathOrig::new(height as u32, test_index);
+            node_hashes
+                .save_node(&mut tx, ts, bit_path, hash_value)
+                .await?;
+        }
+
+        for ts in timestamps {
+            let proof = node_hashes.prove(&mut tx, ts, test_index).await?;
+            let expected_length = height;
+            assert_eq!(
+                proof.siblings.len(),
+                expected_length,
+                "Proof at timestamp {} should have {} siblings",
+                ts,
+                expected_length
+            );
+        }
+
+        tx.rollback().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_prove_all_zero_hashes() -> anyhow::Result<()> {
+        let database_url = setup_test();
+        let pool = PgPoolOptions::new()
+            .max_connections(5)
+            .connect(&database_url)
+            .await?;
+
+        let mut rng = rand::thread_rng();
+        let tag = rng.gen();
+        let height = 10;
+        let node_hashes = SqlNodeHashes::<TestValue>::new(pool.clone(), tag, height);
+
+        let timestamp = 1000;
+        let mut tx = pool.begin().await?;
+
+        let large_indices = [
+            (1 << height) - 2,         // near maximum
+            (1 << (height - 1)) + 123, // intermediate
+            (1 << height) / 3,         // other value
+        ];
+
+        for &index in &large_indices {
+            let proof = node_hashes.prove(&mut tx, timestamp, index).await?;
+
+            let mut path = BitPath::new(height as u32, index);
+            path.reverse();
+            let paths = collect_paths(&path);
+
+            for (i, sibling) in proof.siblings.iter().enumerate() {
+                let sibling_path = paths[i].sibling();
+                let expected_zero_hash = node_hashes.zero_hashes[sibling_path.len() as usize];
+                assert_eq!(
+                    *sibling, expected_zero_hash,
+                    "Sibling hash at position {} for index {} should be zero hash",
+                    i, index
+                );
+            }
+        }
+
+        tx.rollback().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_prove_mixed_zero_and_real_hashes() -> anyhow::Result<()> {
+        let database_url = setup_test();
+        let pool = PgPoolOptions::new()
+            .max_connections(5)
+            .connect(&database_url)
+            .await?;
+
+        let mut rng = rand::thread_rng();
+        let tag = rng.gen();
+        let height = 10;
+        let node_hashes = SqlNodeHashes::<TestValue>::new(pool.clone(), tag, height);
+
+        let timestamp = 1000;
+        let mut tx = pool.begin().await?;
+
+        let test_index = 42;
+        let mut path = BitPath::new(height as u32, test_index);
+        path.reverse();
+
+        let paths = collect_paths(&path);
+
+        for i in (0..paths.len()).step_by(2) {
+            let path_to_save = paths[i];
+            let sibling_path = path_to_save.sibling();
+
+            let custom_hash = TestValue::empty_leaf().hash();
+            node_hashes
+                .save_node(&mut tx, timestamp, sibling_path, custom_hash)
+                .await?;
+        }
+
+        let proof = node_hashes.prove(&mut tx, timestamp, test_index).await?;
+
+        for (i, sibling) in proof.siblings.iter().enumerate() {
+            let sibling_path = paths[i].sibling();
+
+            if i % 2 == 0 {
+                let saved_hash = TestValue::empty_leaf().hash();
+                assert_eq!(
+                    *sibling, saved_hash,
+                    "Sibling hash at position {} should be custom hash",
+                    i
+                );
+            } else {
+                let expected_zero_hash = node_hashes.zero_hashes[sibling_path.len() as usize];
+                assert_eq!(
+                    *sibling, expected_zero_hash,
+                    "Sibling hash at position {} should be zero hash",
+                    i
+                );
+            }
+        }
+
+        tx.rollback().await?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Change Summary
This PR enhances performance optimizations for query hash_nodes and adds comprehensive test coverage:

* Added `bulk_get_sibling_hashes` method to retrieve multiple node hashes with a single SQL query
* Improved the prove method to use bulk retrieval instead of individual hash lookups, reducing database access
* Added `test_speed_incremental_merkle_tree_prove` test to measure `prove` performance
* Added unit tests

## Benchmark Result Summary
performance has significantly improved. The implementation of bulk hash retrieval reduced the time for 5000 proof generations from 63.1 seconds to 7.9 seconds (an 87% reduction).

## Benchmark Results

benchmark script: `validity-prover/src/trees/merkle_tree/mod.rs:test_speed_incremental_merkle_tree_prove`

### Before
```
running 1 test
test trees::merkle_tree::tests::test_speed_incremental_merkle_tree_prove has been running for over 60 seconds
SqlIncrementMerkleTree.prove: 5000 times, 32 height, 63.127032334 seconds
test trees::merkle_tree::tests::test_speed_incremental_merkle_tree_prove ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 17 filtered out; finished in 63.15s
```

```
 schema_name |             table_name              |                index_name                | scans  | index_size | total_size | index_ratio | tuples_read | tuples_fetched
-------------+-------------------------------------+------------------------------------------+--------+------------+------------+-------------+-------------+----------------
 public      | hash_nodes                          | idx_hash_nodes_lookup                    | 159990 | 2592 kB    | 4536 kB    |       57.14 |           0 |              0
 public      | hash_nodes                          | hash_nodes_pkey                          |     21 | 1624 kB    | 4536 kB    |       35.80 |          11 |              0
 public      | leaves_len                          | leaves_len_pkey                          |      1 | 48 kB      | 4536 kB    |        1.06 |           1 |              1
 public      | leaves                              | leaves_pkey                              |      1 | 56 kB      | 4536 kB    |        1.23 |           1 |              1
 public      | leaves_len                          | idx_leaves_len_lookup                    |      1 | 72 kB      | 4536 kB    |        1.59 |           0 |              0
 public      | _sqlx_migrations                    | _sqlx_migrations_pkey                    |      0 | 16 kB      | 4536 kB    |        0.35 |           0 |              0
 public      | tx_tree_roots                       | tx_tree_roots_pkey                       |      0 | 8192 bytes | 4536 kB    |        0.18 |           0 |              0
 public      | validity_proofs                     | validity_proofs_pkey                     |      0 | 8192 bytes | 4536 kB    |        0.18 |           0 |              0
 public      | prover_tasks                        | prover_tasks_pkey                        |      0 | 8192 bytes | 4536 kB    |        0.18 |           0 |              0
 public      | validity_state                      | validity_state_pkey                      |      0 | 8192 bytes | 4536 kB    |        0.18 |           0 |              0
 public      | deposit_leaf_events                 | deposit_leaf_events_pkey                 |      0 | 8192 bytes | 4536 kB    |        0.18 |           0 |              0
 public      | full_blocks                         | full_blocks_pkey                         |      0 | 8192 bytes | 4536 kB    |        0.18 |           0 |              0
 public      | deposit_leaf_events                 | idx_deposit_leaf_events_deposit_hash     |      0 | 8192 bytes | 4536 kB    |        0.18 |           0 |              0
 public      | deposit_leaf_events                 | idx_deposit_leaf_events_block_tx         |      0 | 8192 bytes | 4536 kB    |        0.18 |           0 |              0
 public      | full_blocks                         | idx_full_blocks_block_tx                 |      0 | 8192 bytes | 4536 kB    |        0.18 |           0 |              0
 public      | observer_deposit_sync_eth_block_num | observer_deposit_sync_eth_block_num_pkey |      0 | 8192 bytes | 4536 kB    |        0.18 |           0 |              0
 public      | observer_block_sync_eth_block_num   | observer_block_sync_eth_block_num_pkey   |      0 | 8192 bytes | 4536 kB    |        0.18 |           0 |              0
 public      | indexed_leaves                      | indexed_leaves_pkey                      |      0 | 8192 bytes | 4536 kB    |        0.18 |           0 |              0
 public      | indexed_leaves                      | idx_indexed_leaves_lookup                |      0 | 8192 bytes | 4536 kB    |        0.18 |           0 |              0
 public      | indexed_leaves                      | idx_indexed_leaves_timestamp             |      0 | 8192 bytes | 4536 kB    |        0.18 |           0 |              0
 public      | prover_tasks                        | idx_prover_tasks_assigned_status         |      0 | 8192 bytes | 4536 kB    |        0.18 |           0 |              0
 public      | tx_tree_roots                       | idx_tx_tree_roots_block_number           |      0 | 8192 bytes | 4536 kB    |        0.18 |           0 |              0
(22 rows)
```


### After

```
running 1 test
SqlIncrementMerkleTree.prove: 5000 times, 32 height, 7.857474416 seconds
test trees::merkle_tree::tests::test_speed_incremental_merkle_tree_prove ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 17 filtered out; finished in 7.88s
```

```
 schema_name |             table_name              |                index_name                | scans  | index_size | total_size | index_ratio | tuples_read | tuples_fetched
-------------+-------------------------------------+------------------------------------------+--------+------------+------------+-------------+-------------+----------------
 public      | hash_nodes                          | idx_hash_nodes_lookup                    | 156224 | 2592 kB    | 4536 kB    |       57.14 |           0 |              0
 public      | hash_nodes                          | hash_nodes_pkey                          |   4148 | 1624 kB    | 4536 kB    |       35.80 |        4058 |              0
 public      | leaves_len                          | leaves_len_pkey                          |      1 | 48 kB      | 4536 kB    |        1.06 |           1 |              1
 public      | leaves                              | leaves_pkey                              |      1 | 56 kB      | 4536 kB    |        1.23 |           1 |              1
 public      | leaves_len                          | idx_leaves_len_lookup                    |      1 | 72 kB      | 4536 kB    |        1.59 |           0 |              0
 public      | _sqlx_migrations                    | _sqlx_migrations_pkey                    |      0 | 16 kB      | 4536 kB    |        0.35 |           0 |              0
 public      | tx_tree_roots                       | tx_tree_roots_pkey                       |      0 | 8192 bytes | 4536 kB    |        0.18 |           0 |              0
 public      | validity_proofs                     | validity_proofs_pkey                     |      0 | 8192 bytes | 4536 kB    |        0.18 |           0 |              0
 public      | prover_tasks                        | prover_tasks_pkey                        |      0 | 8192 bytes | 4536 kB    |        0.18 |           0 |              0
 public      | validity_state                      | validity_state_pkey                      |      0 | 8192 bytes | 4536 kB    |        0.18 |           0 |              0
 public      | deposit_leaf_events                 | deposit_leaf_events_pkey                 |      0 | 8192 bytes | 4536 kB    |        0.18 |           0 |              0
 public      | full_blocks                         | full_blocks_pkey                         |      0 | 8192 bytes | 4536 kB    |        0.18 |           0 |              0
 public      | deposit_leaf_events                 | idx_deposit_leaf_events_deposit_hash     |      0 | 8192 bytes | 4536 kB    |        0.18 |           0 |              0
 public      | deposit_leaf_events                 | idx_deposit_leaf_events_block_tx         |      0 | 8192 bytes | 4536 kB    |        0.18 |           0 |              0
 public      | full_blocks                         | idx_full_blocks_block_tx                 |      0 | 8192 bytes | 4536 kB    |        0.18 |           0 |              0
 public      | observer_deposit_sync_eth_block_num | observer_deposit_sync_eth_block_num_pkey |      0 | 8192 bytes | 4536 kB    |        0.18 |           0 |              0
 public      | observer_block_sync_eth_block_num   | observer_block_sync_eth_block_num_pkey   |      0 | 8192 bytes | 4536 kB    |        0.18 |           0 |              0
 public      | indexed_leaves                      | indexed_leaves_pkey                      |      0 | 8192 bytes | 4536 kB    |        0.18 |           0 |              0
 public      | indexed_leaves                      | idx_indexed_leaves_lookup                |      0 | 8192 bytes | 4536 kB    |        0.18 |           0 |              0
 public      | indexed_leaves                      | idx_indexed_leaves_timestamp             |      0 | 8192 bytes | 4536 kB    |        0.18 |           0 |              0
 public      | prover_tasks                        | idx_prover_tasks_assigned_status         |      0 | 8192 bytes | 4536 kB    |        0.18 |           0 |              0
 public      | tx_tree_roots                       | idx_tx_tree_roots_block_number           |      0 | 8192 bytes | 4536 kB    |        0.18 |           0 |              0
(22 rows)
```