### PR TITLE
avoid conflict test and set num-cpus for nextest test-threads

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,7 +1,7 @@
 [profile.default]
 slow-timeout = "2m"
 fail-fast = true
-test-threads = 1
+test-threads = "num-cpus"
 
 [profile.ci]
 fail-fast = false

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Install dependency 
+
 - Install Rust
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh

--- a/validity-prover/src/trees/merkle_tree/sql_indexed_merkle_tree.rs
+++ b/validity-prover/src/trees/merkle_tree/sql_indexed_merkle_tree.rs
@@ -686,7 +686,7 @@ mod tests {
     #[tokio::test]
     async fn test_comparison_account_tree() -> anyhow::Result<()> {
         let database_url = crate::trees::setup_test();
-        let tag = 3;
+        let tag = 4;
         let pool = sqlx::Pool::connect(&database_url).await?;
         let db_tree = SqlIndexedMerkleTree::new(pool, tag, ACCOUNT_TREE_HEIGHT);
         <SqlIndexedMerkleTree as IndexedMerkleTreeClient>::reset(&db_tree, 0).await?;


### PR DESCRIPTION
## Change Summary

* modified Nextest configuration to change test thread count from a fixed value to "number of available CPUs"
* avoid risk of interference between test cases (using different tag values)

## Pros

* Improved test execution speed (maximizing multi-core CPU utilization)

### before
https://github.com/InternetMaximalism/intmax2/actions/runs/13892225012/job/38866040655#step:13:66
```
     Summary [ 406.146s] 28 tests run: 28 passed (2 slow), 11 skipped
```

### after
https://github.com/InternetMaximalism/intmax2/actions/runs/13961515454/job/39083596369#step:13:60
```
     Summary [ 158.047s] 28 tests run: 28 passed (2 slow), 11 skipped
```