### PR TITLE
Fix store vault auth in WASM & parallel download/upload

### DIFF
--- a/interfaces/src/api/s3_store_vault/types.rs
+++ b/interfaces/src/api/s3_store_vault/types.rs
@@ -119,7 +119,7 @@ pub struct S3GetDataBatchRequest {
 
 impl Signable for S3GetDataBatchRequest {
     fn content(&self) -> Vec<u8> {
-        // to reuse the signature, we exclude data_type and uuids from the content intentionally
+        // to reuse the signature, we exclude topic and digests from the content intentionally
         content_prefix("get_data_batch")
     }
 }
@@ -140,7 +140,7 @@ pub struct S3GetDataSequenceRequest {
 
 impl Signable for S3GetDataSequenceRequest {
     fn content(&self) -> Vec<u8> {
-        // to reuse the signature, we exclude data_type and cursor from the content intentionally
+        // to reuse the signature, we exclude topic and cursor from the content intentionally
         content_prefix("get_data_sequence")
     }
 }

--- a/wasm/js-test/src/store_vault.ts
+++ b/wasm/js-test/src/store_vault.ts
@@ -7,7 +7,7 @@ async function main() {
     const privkey = key.privkey;
 
     // get auth for store vault using private key
-    const auth = await generate_auth_for_store_vault(privkey);
+    const auth = await generate_auth_for_store_vault(privkey, env.USE_S3);
     console.log(`auth: pubkey ${auth.pubkey}, expiry ${auth.expiry}`);
 
     // get latest 10 encrypted data

--- a/wasm/src/native.rs
+++ b/wasm/src/native.rs
@@ -10,7 +10,10 @@ use crate::{
     },
     utils::{parse_h256_as_u256, str_privkey_to_keyset},
 };
-use intmax2_client_sdk::external_api::store_vault_server::generate_auth_for_get_data_sequence;
+use intmax2_client_sdk::external_api::{
+    s3_store_vault::generate_auth_for_get_data_sequence_s3,
+    store_vault_server::generate_auth_for_get_data_sequence,
+};
 use intmax2_interfaces::{
     api::store_vault_server::types::{CursorOrder, MetaDataCursor},
     data::{
@@ -62,10 +65,17 @@ pub async fn decrypt_tx_data(private_key: &str, data: &[u8]) -> Result<JsTxData,
 }
 
 #[wasm_bindgen]
-pub async fn generate_auth_for_store_vault(private_key: &str) -> Result<JsAuth, JsError> {
+pub async fn generate_auth_for_store_vault(
+    private_key: &str,
+    use_s3: bool,
+) -> Result<JsAuth, JsError> {
     init_logger();
     let key = str_privkey_to_keyset(private_key)?;
-    let auth = generate_auth_for_get_data_sequence(key);
+    let auth = if use_s3 {
+        generate_auth_for_get_data_sequence_s3(key)
+    } else {
+        generate_auth_for_get_data_sequence(key)
+    };
     Ok(auth.into())
 }
 


### PR DESCRIPTION
- Implemented parallel execution for upload/download operations in the S3 store vault client.
- Added `use_s3` as the second parameter to the `generate_auth_for_store_vault` function in the Wasm implementation.