### PR TITLE
Add block builder cluster id

### DIFF
--- a/block-builder/.env.example
+++ b/block-builder/.env.example
@@ -9,6 +9,7 @@ INITIAL_HEART_BEAT_DELAY=600
 HEART_BEAT_INTERVAL=86400
 INITIAL_MAX_PRIORITY_FEE_PER_GAS="31337:500000000"
 BLOCK_BUILDER_URL="http://localhost:9004"
+CLUSTER_ID="1" # if set, the block builder uses the cluster id for prefix of redis key
 REDIS_URL="redis://localhost:6379" # if set, the block builder uses the redis for the queue
 
 # fee settings

--- a/block-builder/src/app/block_builder.rs
+++ b/block-builder/src/app/block_builder.rs
@@ -195,6 +195,7 @@ impl BlockBuilder {
             proposing_block_interval: env.proposing_block_interval,
             deposit_check_interval: env.deposit_check_interval,
             redis_url: env.redis_url.clone(),
+            cluster_id: env.cluster_id.clone(),
             block_builder_id: Uuid::new_v4().to_string(),
         };
 

--- a/block-builder/src/app/storage/config.rs
+++ b/block-builder/src/app/storage/config.rs
@@ -13,4 +13,5 @@ pub struct StorageConfig {
 
     // Redis configuration
     pub redis_url: Option<String>,
+    pub cluster_id: Option<String>,
 }

--- a/block-builder/src/app/storage/redis_storage.rs
+++ b/block-builder/src/app/storage/redis_storage.rs
@@ -259,9 +259,11 @@ impl RedisStorage {
     /// Initializes Redis connection and sets up keys for shared state.
     pub async fn new(config: &StorageConfig) -> Self {
         log::info!("Initializing Redis storage");
-        // Create a common prefix for all block builder instances to share the same state
-        let prefix = "block_builder:shared";
-
+        let cluster_id = config
+            .cluster_id
+            .clone()
+            .unwrap_or_else(|| "default".to_string());
+        let prefix = format!("block_builder:{}", cluster_id);
         // Create Redis client with fallback to localhost if URL not provided
         let redis_url = config.redis_url.clone().expect("redis_url not found");
         let client = Client::open(redis_url).expect("Failed to create Redis client");

--- a/block-builder/src/lib.rs
+++ b/block-builder/src/lib.rs
@@ -9,6 +9,7 @@ pub struct EnvVar {
     pub port: u16,
     pub block_builder_url: String,
     pub redis_url: Option<String>,
+    pub cluster_id: Option<String>,
     pub l2_rpc_url: String,
     pub l2_chain_id: u64,
     pub rollup_contract_address: Address,


### PR DESCRIPTION
When you specify a `CLUSTER_ID`, that value is used as a prefix in Redis. This is useful when running multiple block builder clusters on the same Redis instance.