### PR TITLE
Fixed Timeout and Duplicate Fetch Problems

### DIFF
--- a/client-sdk/src/client/client.rs
+++ b/client-sdk/src/client/client.rs
@@ -624,11 +624,13 @@ impl Client {
     }
 
     pub async fn get_mining_list(&self, key: KeySet) -> Result<Vec<Mining>, ClientError> {
+        let current_time = chrono::Utc::now().timestamp() as u64;
         let minings = fetch_mining_info(
             self.store_vault_server.as_ref(),
             self.validity_prover.as_ref(),
             &self.liquidity_contract,
             key,
+            current_time,
             &ProcessStatus::default(),
             self.config.tx_timeout,
             self.config.deposit_timeout,

--- a/client-sdk/src/client/history.rs
+++ b/client-sdk/src/client/history.rs
@@ -51,6 +51,9 @@ pub async fn fetch_deposit_history(
     key: KeySet,
     cursor: &MetaDataCursor,
 ) -> Result<(Vec<HistoryEntry<DepositData>>, MetaDataCursorResponse), ClientError> {
+    // We don't need to check validity prover's sync status like in strategy
+    // because fetching history is not a critical operation.
+    let current_time = chrono::Utc::now().timestamp() as u64;
     let user_data = client.get_user_data(key).await?;
 
     let mut history = Vec::new();
@@ -59,6 +62,7 @@ pub async fn fetch_deposit_history(
         client.validity_prover.as_ref(),
         &client.liquidity_contract,
         key,
+        current_time,
         &[],
         &[],
         cursor,
@@ -103,6 +107,7 @@ pub async fn fetch_transfer_history(
     key: KeySet,
     cursor: &MetaDataCursor,
 ) -> Result<(Vec<HistoryEntry<TransferData>>, MetaDataCursorResponse), ClientError> {
+    let current_time = chrono::Utc::now().timestamp() as u64;
     let user_data = client.get_user_data(key).await?;
 
     let mut history = Vec::new();
@@ -110,6 +115,7 @@ pub async fn fetch_transfer_history(
         client.store_vault_server.as_ref(),
         client.validity_prover.as_ref(),
         key,
+        current_time,
         &[],
         &[],
         cursor,
@@ -154,6 +160,7 @@ pub async fn fetch_tx_history(
     key: KeySet,
     cursor: &MetaDataCursor,
 ) -> Result<(Vec<HistoryEntry<TxData>>, MetaDataCursorResponse), ClientError> {
+    let current_time = chrono::Utc::now().timestamp() as u64;
     let user_data = client.get_user_data(key).await?;
 
     let mut history = Vec::new();
@@ -161,6 +168,7 @@ pub async fn fetch_tx_history(
         client.store_vault_server.as_ref(),
         client.validity_prover.as_ref(),
         key,
+        current_time,
         &[],
         &[],
         cursor,

--- a/client-sdk/src/client/strategy/deposit.rs
+++ b/client-sdk/src/client/strategy/deposit.rs
@@ -35,6 +35,7 @@ pub async fn fetch_deposit_info(
     validity_prover: &dyn ValidityProverClientInterface,
     liquidity_contract: &LiquidityContract,
     key: KeySet,
+    current_time: u64, // current timestamp for timeout checking
     included_digests: &[Bytes32],
     excluded_digests: &[Bytes32],
     cursor: &MetaDataCursor,
@@ -94,7 +95,7 @@ pub async fn fetch_deposit_info(
                 };
                 settled.push((meta, deposit_data));
             }
-            None if meta.timestamp + deposit_timeout < chrono::Utc::now().timestamp() as u64 => {
+            None if meta.timestamp + deposit_timeout < current_time => {
                 // Deposit has timed out
                 log::error!(
                     "Deposit digest: {}, deposit_hash: {} is timeout",
@@ -136,6 +137,7 @@ pub async fn fetch_all_unprocessed_deposit_info(
     validity_prover: &dyn ValidityProverClientInterface,
     liquidity_contract: &LiquidityContract,
     key: KeySet,
+    current_time: u64,
     process_status: &ProcessStatus,
     deposit_timeout: u64,
 ) -> Result<DepositInfo, StrategyError> {
@@ -162,6 +164,7 @@ pub async fn fetch_all_unprocessed_deposit_info(
             validity_prover,
             liquidity_contract,
             key,
+            current_time,
             &included_digests,
             &process_status.processed_digests,
             &cursor,

--- a/client-sdk/src/client/strategy/deposit.rs
+++ b/client-sdk/src/client/strategy/deposit.rs
@@ -146,7 +146,7 @@ pub async fn fetch_all_unprocessed_deposit_info(
         order: CursorOrder::Asc,
         limit: None,
     };
-    let mut included_digests = process_status.processed_digests.clone(); // cleared after first fetch
+    let mut included_digests = process_status.pending_digests.clone(); // cleared after first fetch
 
     let mut settled = Vec::new();
     let mut pending = Vec::new();

--- a/client-sdk/src/client/strategy/error.rs
+++ b/client-sdk/src/client/strategy/error.rs
@@ -20,6 +20,9 @@ pub enum StrategyError {
     #[error("Blockchain error: {0}")]
     BlockchainError(#[from] BlockchainError),
 
+    #[error("Validity prover is not up to date: {0}")]
+    ValidityProverIsNotSynced(String),
+
     #[error("Balance insufficient before sync")]
     BalanceInsufficientBeforeSync,
 

--- a/client-sdk/src/client/strategy/mining.rs
+++ b/client-sdk/src/client/strategy/mining.rs
@@ -52,11 +52,13 @@ impl Display for MiningStatus {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn fetch_mining_info(
     store_vault_server: &dyn StoreVaultClientInterface,
     validity_prover: &dyn ValidityProverClientInterface,
     liquidity_contract: &LiquidityContract,
     key: KeySet,
+    current_time: u64, // current timestamp for timeout checking
     claim_status: &ProcessStatus,
     tx_timeout: u64,
     deposit_timeout: u64,
@@ -67,6 +69,7 @@ pub async fn fetch_mining_info(
         validity_prover,
         liquidity_contract,
         key,
+        current_time,
         &ProcessStatus::default(),
         deposit_timeout,
     )
@@ -106,6 +109,7 @@ pub async fn fetch_mining_info(
         store_vault_server,
         validity_prover,
         key,
+        current_time,
         &ProcessStatus::default(),
         tx_timeout,
     )

--- a/client-sdk/src/client/strategy/mod.rs
+++ b/client-sdk/src/client/strategy/mod.rs
@@ -7,4 +7,5 @@ pub mod strategy;
 pub mod transfer;
 pub mod tx;
 pub mod tx_status;
+pub mod utils;
 pub mod withdrawal;

--- a/client-sdk/src/client/strategy/strategy.rs
+++ b/client-sdk/src/client/strategy/strategy.rs
@@ -15,6 +15,7 @@ use intmax2_zkp::{
     ethereum_types::{bytes32::Bytes32, u32limb_trait::U32LimbTrait},
 };
 
+use super::{error::StrategyError, mining::Mining};
 use crate::{
     client::strategy::{
         common::fetch_user_data,
@@ -23,12 +24,13 @@ use crate::{
         transfer::fetch_all_unprocessed_transfer_info,
         tx::fetch_all_unprocessed_tx_info,
         tx_status::{get_tx_status, TxStatus},
+        utils::wait_till_validity_prover_synced,
         withdrawal::fetch_all_unprocessed_withdrawal_info,
     },
-    external_api::contract::liquidity_contract::LiquidityContract,
+    external_api::contract::{
+        liquidity_contract::LiquidityContract, rollup_contract::RollupContract,
+    },
 };
-
-use super::{error::StrategyError, mining::Mining};
 
 // Next sync action
 #[derive(Debug, Clone)]
@@ -73,14 +75,20 @@ pub struct PendingInfo {
 pub async fn determine_sequence(
     store_vault_server: &dyn StoreVaultClientInterface,
     validity_prover: &dyn ValidityProverClientInterface,
+    rollup_contract: &RollupContract,
     liquidity_contract: &LiquidityContract,
     key: KeySet,
     deposit_timeout: u64,
     tx_timeout: u64,
 ) -> Result<(Vec<Action>, PendingInfo), StrategyError> {
     log::info!("determine_sequence");
-    let user_data = fetch_user_data(store_vault_server, key).await?;
 
+    // Wait until the validity prover catches up with the onchain block number
+    let current_time = chrono::Utc::now().timestamp() as u64;
+    let onchain_block_number = rollup_contract.get_latest_block_number().await?;
+    wait_till_validity_prover_synced(validity_prover, false, onchain_block_number).await?;
+
+    let user_data = fetch_user_data(store_vault_server, key).await?;
     let mut nonce = user_data.full_private_state.nonce;
     let mut balances = user_data.balances();
     if balances.is_insufficient() {
@@ -91,6 +99,7 @@ pub async fn determine_sequence(
         store_vault_server,
         validity_prover,
         key,
+        current_time,
         &user_data.tx_status,
         tx_timeout,
     )
@@ -110,6 +119,7 @@ pub async fn determine_sequence(
         validity_prover,
         liquidity_contract,
         key,
+        current_time,
         &user_data.deposit_status,
         deposit_timeout,
     )
@@ -118,6 +128,7 @@ pub async fn determine_sequence(
         store_vault_server,
         validity_prover,
         key,
+        current_time,
         &user_data.transfer_status,
         tx_timeout,
     )
@@ -281,6 +292,7 @@ async fn collect_receives(
 pub async fn determine_withdrawals(
     store_vault_server: &dyn StoreVaultClientInterface,
     validity_prover: &dyn ValidityProverClientInterface,
+    rollup_contract: &RollupContract,
     key: KeySet,
     tx_timeout: u64,
 ) -> Result<
@@ -291,11 +303,18 @@ pub async fn determine_withdrawals(
     StrategyError,
 > {
     log::info!("determine_withdrawals");
+
+    // Wait until the validity prover catches up with the onchain block number
+    let current_time = chrono::Utc::now().timestamp() as u64;
+    let onchain_block_number = rollup_contract.get_latest_block_number().await?;
+    wait_till_validity_prover_synced(validity_prover, false, onchain_block_number).await?;
+
     let user_data = fetch_user_data(store_vault_server, key).await?;
     let withdrawal_info = fetch_all_unprocessed_withdrawal_info(
         store_vault_server,
         validity_prover,
         key,
+        current_time,
         &user_data.withdrawal_status,
         tx_timeout,
     )
@@ -312,18 +331,26 @@ pub async fn determine_withdrawals(
 pub async fn determine_claims(
     store_vault_server: &dyn StoreVaultClientInterface,
     validity_prover: &dyn ValidityProverClientInterface,
+    rollup_contract: &RollupContract,
     liquidity_contract: &LiquidityContract,
     key: KeySet,
     tx_timeout: u64,
     deposit_timeout: u64,
 ) -> Result<Vec<Mining>, StrategyError> {
     log::info!("determine_claims");
+
+    // Wait until the validity prover catches up with the onchain block number
+    let current_time = chrono::Utc::now().timestamp() as u64;
+    let onchain_block_number = rollup_contract.get_latest_block_number().await?;
+    wait_till_validity_prover_synced(validity_prover, false, onchain_block_number).await?;
+
     let user_data = fetch_user_data(store_vault_server, key).await?;
     let minings = fetch_mining_info(
         store_vault_server,
         validity_prover,
         liquidity_contract,
         key,
+        current_time,
         &user_data.claim_status,
         tx_timeout,
         deposit_timeout,

--- a/client-sdk/src/client/strategy/transfer.rs
+++ b/client-sdk/src/client/strategy/transfer.rs
@@ -32,10 +32,12 @@ pub struct TransferInfo {
     pub timeout: Vec<(MetaData, TransferData)>,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn fetch_transfer_info(
     store_vault_server: &dyn StoreVaultClientInterface,
     validity_prover: &dyn ValidityProverClientInterface,
     key: KeySet,
+    current_time: u64, // current timestamp for timeout checking
     included_digests: &[Bytes32],
     excluded_digests: &[Bytes32],
     cursor: &MetaDataCursor,
@@ -109,9 +111,6 @@ pub async fn fetch_transfer_info(
         .get_block_number_by_tx_tree_root_batch(&tx_tree_roots)
         .await?;
 
-    // Current timestamp for timeout checking
-    let current_time = chrono::Utc::now().timestamp() as u64;
-
     // Process results and categorize transfers
     for ((meta, transfer_data), block_number) in valid_transfers.into_iter().zip(block_numbers) {
         match block_number {
@@ -157,6 +156,7 @@ pub async fn fetch_all_unprocessed_transfer_info(
     store_vault_server: &dyn StoreVaultClientInterface,
     validity_prover: &dyn ValidityProverClientInterface,
     key: KeySet,
+    current_time: u64,
     process_status: &ProcessStatus,
     tx_timeout: u64,
 ) -> Result<TransferInfo, StrategyError> {
@@ -182,6 +182,7 @@ pub async fn fetch_all_unprocessed_transfer_info(
             store_vault_server,
             validity_prover,
             key,
+            current_time,
             &included_digests,
             &process_status.processed_digests,
             &cursor,

--- a/client-sdk/src/client/strategy/transfer.rs
+++ b/client-sdk/src/client/strategy/transfer.rs
@@ -165,7 +165,7 @@ pub async fn fetch_all_unprocessed_transfer_info(
         order: CursorOrder::Asc,
         limit: None,
     };
-    let mut included_digests = process_status.processed_digests.clone(); // cleared after first fetch
+    let mut included_digests = process_status.pending_digests.clone(); // cleared after first fetch
 
     let mut settled = Vec::new();
     let mut pending = Vec::new();

--- a/client-sdk/src/client/strategy/tx.rs
+++ b/client-sdk/src/client/strategy/tx.rs
@@ -26,10 +26,12 @@ pub struct TxInfo {
     pub timeout: Vec<(MetaData, TxData)>,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn fetch_tx_info(
     store_vault_server: &dyn StoreVaultClientInterface,
     validity_prover: &dyn ValidityProverClientInterface,
     key: KeySet,
+    current_time: u64, // current timestamp for timeout checking
     included_digests: &[Bytes32],
     excluded_digests: &[Bytes32],
     cursor: &MetaDataCursor,
@@ -57,9 +59,6 @@ pub async fn fetch_tx_info(
     let block_numbers = validity_prover
         .get_block_number_by_tx_tree_root_batch(&tx_tree_roots)
         .await?;
-
-    // Current timestamp for timeout checking
-    let current_time = chrono::Utc::now().timestamp() as u64;
 
     // Process results and categorize transactions
     for ((meta, tx_data), block_number) in data_with_meta.into_iter().zip(block_numbers) {
@@ -106,6 +105,7 @@ pub async fn fetch_all_unprocessed_tx_info(
     store_vault_server: &dyn StoreVaultClientInterface,
     validity_prover: &dyn ValidityProverClientInterface,
     key: KeySet,
+    current_time: u64,
     process_status: &ProcessStatus,
     tx_timeout: u64,
 ) -> Result<TxInfo, StrategyError> {
@@ -131,6 +131,7 @@ pub async fn fetch_all_unprocessed_tx_info(
             store_vault_server,
             validity_prover,
             key,
+            current_time,
             &included_digests,
             &process_status.processed_digests,
             &cursor,

--- a/client-sdk/src/client/strategy/tx.rs
+++ b/client-sdk/src/client/strategy/tx.rs
@@ -114,7 +114,7 @@ pub async fn fetch_all_unprocessed_tx_info(
         order: CursorOrder::Asc,
         limit: None,
     };
-    let mut included_digests = process_status.processed_digests.clone(); // cleared after first fetch
+    let mut included_digests = process_status.pending_digests.clone(); // cleared after first fetch
 
     let mut settled = Vec::new();
     let mut pending = Vec::new();

--- a/client-sdk/src/client/strategy/utils.rs
+++ b/client-sdk/src/client/strategy/utils.rs
@@ -1,0 +1,57 @@
+use intmax2_interfaces::api::validity_prover::interface::ValidityProverClientInterface;
+
+use crate::external_api::utils::time::sleep_for;
+
+use super::error::StrategyError;
+
+const VALIDITY_PROVER_SYNC_SLEEP_TIME: u64 = 5;
+const MAX_SYNC_TRIES: u32 = 5;
+const MAX_PROOF_SYNC_TRIES: u32 = 20;
+
+pub async fn wait_till_validity_prover_synced(
+    validity_prover: &dyn ValidityProverClientInterface,
+    wait_for_proof: bool,
+    block_number: u32,
+) -> Result<(), StrategyError> {
+    let mut tries = 0;
+    let mut synced_block_number = validity_prover.get_block_number().await?;
+    while synced_block_number < block_number {
+        if tries > MAX_SYNC_TRIES {
+            return Err(StrategyError::ValidityProverIsNotSynced(format!(
+                "expected block number {} but got {} after {} tries",
+                block_number, synced_block_number, tries
+            )));
+        }
+        tries += 1;
+        log::warn!(
+            "validity prover is not synced with block number {}, current block number is {}",
+            block_number,
+            synced_block_number
+        );
+
+        sleep_for(VALIDITY_PROVER_SYNC_SLEEP_TIME).await;
+        synced_block_number = validity_prover.get_block_number().await?;
+    }
+    if !wait_for_proof {
+        return Ok(());
+    }
+    let mut validity_proof_block_number = validity_prover.get_validity_proof_block_number().await?;
+    while validity_proof_block_number < block_number {
+        if tries > MAX_PROOF_SYNC_TRIES {
+            return Err(StrategyError::ValidityProverIsNotSynced(format!(
+                "expected validity proof block number {} but got {} after {} tries",
+                block_number, validity_proof_block_number, tries
+            )));
+        }
+        tries += 1;
+        log::warn!(
+            "validity prover has not synced with validity proof block number {}, current validity proof block number is {}",
+            block_number,
+            validity_proof_block_number
+        );
+        sleep_for(VALIDITY_PROVER_SYNC_SLEEP_TIME).await;
+        validity_proof_block_number = validity_prover.get_validity_proof_block_number().await?;
+    }
+
+    Ok(())
+}

--- a/client-sdk/src/client/strategy/withdrawal.rs
+++ b/client-sdk/src/client/strategy/withdrawal.rs
@@ -157,7 +157,7 @@ pub async fn fetch_all_unprocessed_withdrawal_info(
         order: CursorOrder::Asc,
         limit: None,
     };
-    let mut included_digests = process_status.processed_digests.clone(); // cleared after first fetch
+    let mut included_digests = process_status.pending_digests.clone(); // cleared after first fetch
 
     let mut settled = Vec::new();
     let mut pending = Vec::new();

--- a/client-sdk/src/client/strategy/withdrawal.rs
+++ b/client-sdk/src/client/strategy/withdrawal.rs
@@ -30,10 +30,12 @@ pub struct WithdrawalInfo {
     pub timeout: Vec<(MetaData, TransferData)>,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn fetch_withdrawal_info(
     store_vault_server: &dyn StoreVaultClientInterface,
     validity_prover: &dyn ValidityProverClientInterface,
     key: KeySet,
+    current_time: u64, // current timestamp for timeout checking
     included_digests: &[Bytes32],
     excluded_digests: &[Bytes32],
     cursor: &MetaDataCursor,
@@ -101,9 +103,6 @@ pub async fn fetch_withdrawal_info(
         .get_block_number_by_tx_tree_root_batch(&tx_tree_roots)
         .await?;
 
-    // Current timestamp for timeout checking
-    let current_time = chrono::Utc::now().timestamp() as u64;
-
     // Process results and categorize transfers
     for ((meta, transfer_data), block_number) in valid_transfers.into_iter().zip(block_numbers) {
         match block_number {
@@ -149,6 +148,7 @@ pub async fn fetch_all_unprocessed_withdrawal_info(
     store_vault_server: &dyn StoreVaultClientInterface,
     validity_prover: &dyn ValidityProverClientInterface,
     key: KeySet,
+    current_time: u64, // current timestamp for timeout checking
     process_status: &ProcessStatus,
     tx_timeout: u64,
 ) -> Result<WithdrawalInfo, StrategyError> {
@@ -174,6 +174,7 @@ pub async fn fetch_all_unprocessed_withdrawal_info(
             store_vault_server,
             validity_prover,
             key,
+            current_time,
             &included_digests,
             &process_status.processed_digests,
             &cursor,

--- a/client-sdk/src/client/sync/error.rs
+++ b/client-sdk/src/client/sync/error.rs
@@ -53,9 +53,6 @@ pub enum SyncError {
     #[error("Failed to update private state: {0}")]
     FailedToUpdatePrivateState(String),
 
-    #[error("Validity prover is not up to date: {0}")]
-    ValidityProverIsNotSynced(String),
-
     #[error("Deposit info not found: {0}")]
     DepositInfoNotFound(Bytes32),
 

--- a/client-sdk/src/client/sync/sync_balance.rs
+++ b/client-sdk/src/client/sync/sync_balance.rs
@@ -74,6 +74,7 @@ impl Client {
         let (sequence, pending_info) = determine_sequence(
             self.store_vault_server.as_ref(),
             self.validity_prover.as_ref(),
+            &self.rollup_contract,
             &self.liquidity_contract,
             key,
             self.config.deposit_timeout,

--- a/client-sdk/src/client/sync/sync_claims.rs
+++ b/client-sdk/src/client/sync/sync_claims.rs
@@ -13,8 +13,9 @@ use intmax2_zkp::{
 use crate::client::{
     client::Client,
     fee_payment::{consume_payment, select_unused_fees, FeeType},
-    strategy::{mining::MiningStatus, strategy::determine_claims},
-    sync::utils::wait_till_validity_prover_synced,
+    strategy::{
+        mining::MiningStatus, strategy::determine_claims, utils::wait_till_validity_prover_synced,
+    },
 };
 
 use super::{error::SyncError, utils::quote_withdrawal_claim_fee};
@@ -35,6 +36,7 @@ impl Client {
         let minings = determine_claims(
             self.store_vault_server.as_ref(),
             self.validity_prover.as_ref(),
+            &self.rollup_contract,
             &self.liquidity_contract,
             key,
             self.config.tx_timeout,
@@ -56,8 +58,12 @@ impl Client {
                 }
             };
 
-            wait_till_validity_prover_synced(self.validity_prover.as_ref(), claim_block_number)
-                .await?;
+            wait_till_validity_prover_synced(
+                self.validity_prover.as_ref(),
+                true,
+                claim_block_number,
+            )
+            .await?;
 
             // collect witnesses
             let deposit_block_number = mining.block.block_number;

--- a/client-sdk/src/client/sync/sync_withdrawals.rs
+++ b/client-sdk/src/client/sync/sync_withdrawals.rs
@@ -37,6 +37,7 @@ impl Client {
         let (withdrawals, pending) = determine_withdrawals(
             self.store_vault_server.as_ref(),
             self.validity_prover.as_ref(),
+            &self.rollup_contract,
             key,
             self.config.tx_timeout,
         )

--- a/client-sdk/src/client/sync/utils.rs
+++ b/client-sdk/src/client/sync/utils.rs
@@ -1,9 +1,4 @@
-use intmax2_interfaces::{
-    api::{
-        block_builder::interface::Fee, validity_prover::interface::ValidityProverClientInterface,
-    },
-    data::user_data::UserData,
-};
+use intmax2_interfaces::{api::block_builder::interface::Fee, data::user_data::UserData};
 use intmax2_zkp::{
     common::{
         private_state::FullPrivateState, salt::Salt, transfer::Transfer,
@@ -15,8 +10,6 @@ use plonky2::{
     field::goldilocks_field::GoldilocksField,
     plonk::{config::PoseidonGoldilocksConfig, proof::ProofWithPublicInputs},
 };
-
-use crate::external_api::utils::time::sleep_for;
 
 use super::error::SyncError;
 
@@ -92,51 +85,4 @@ pub fn get_balance_proof(
         .map(|bp| bp.decompress())
         .transpose()?;
     Ok(balance_proof)
-}
-
-const MAX_VALIDITY_PROVER_SYNC_TRIES: u32 = 20;
-const VALIDITY_PROVER_SYNC_SLEEP_TIME: u64 = 5;
-
-pub async fn wait_till_validity_prover_synced(
-    validity_prover: &dyn ValidityProverClientInterface,
-    block_number: u32,
-) -> Result<(), SyncError> {
-    let mut tries = 0;
-    let mut synced_block_number = validity_prover.get_block_number().await?;
-    while synced_block_number < block_number {
-        if tries > MAX_VALIDITY_PROVER_SYNC_TRIES {
-            return Err(SyncError::ValidityProverIsNotSynced(format!(
-                "tried to sync block number {} for {} times but still not synced",
-                block_number, tries
-            )));
-        }
-        tries += 1;
-        log::warn!(
-            "validity prover is not synced with block number {}, current block number is {}",
-            block_number,
-            synced_block_number
-        );
-
-        sleep_for(VALIDITY_PROVER_SYNC_SLEEP_TIME).await;
-        synced_block_number = validity_prover.get_block_number().await?;
-    }
-
-    let mut validity_proof_block_number = validity_prover.get_validity_proof_block_number().await?;
-    while validity_proof_block_number < block_number {
-        if tries > MAX_VALIDITY_PROVER_SYNC_TRIES {
-            return Err(SyncError::ValidityProverIsNotSynced(format!(
-                "tried to sync validity proof block number {} for {} times but still not synced",
-                block_number, tries
-            )));
-        }
-        tries += 1;
-        log::warn!(
-            "validity prover is not synced with validity proof block number {}, current validity proof block number is {}",
-            block_number,
-            validity_proof_block_number
-        );
-        sleep_for(VALIDITY_PROVER_SYNC_SLEEP_TIME).await;
-        validity_proof_block_number = validity_prover.get_validity_proof_block_number().await?;
-    }
-    Ok(())
 }


### PR DESCRIPTION
There was an issue where data that shouldn't time out was incorrectly timing out when the validity prover wasn't synchronized. This problem was resolved by changing the current time used for timeout determination to a time when the validity prover's synchronization is guaranteed to be complete.

Additionally, a bug was fixed where `processed_digest` and `pending_digest` were confused with each other, which had caused duplicate fetching.