### PR TITLE
Specify private zkp server's retry setting via env.

### DIFF
--- a/cli/src/cli/client.rs
+++ b/cli/src/cli/client.rs
@@ -7,7 +7,7 @@ use intmax2_client_sdk::{
             liquidity_contract::LiquidityContract, rollup_contract::RollupContract,
             withdrawal_contract::WithdrawalContract,
         },
-        private_zkp_server::PrivateZKPServerClient,
+        private_zkp_server::{PrivateZKPServerClient, PrivateZKPServerConfig},
         s3_store_vault::S3StoreVaultClient,
         store_vault_server::StoreVaultServerClient,
         validity_prover::ValidityProverClient,
@@ -39,7 +39,14 @@ pub fn get_client() -> Result<Client, CliError> {
     let validity_prover = Box::new(ValidityProverClient::new(&env.validity_prover_base_url));
     let balance_prover: Box<dyn BalanceProverClientInterface> =
         if env.use_private_zkp_server.unwrap_or(true) {
-            Box::new(PrivateZKPServerClient::new(&env.balance_prover_base_url))
+            let private_zkp_server_config = PrivateZKPServerConfig {
+                max_retries: env.private_zkp_server_max_retires.unwrap_or(30),
+                retry_interval: env.private_zkp_server_retry_interval.unwrap_or(5),
+            };
+            Box::new(PrivateZKPServerClient::new(
+                &env.balance_prover_base_url,
+                &private_zkp_server_config,
+            ))
         } else {
             Box::new(BalanceProverClient::new(&env.balance_prover_base_url))
         };

--- a/cli/src/env_var.rs
+++ b/cli/src/env_var.rs
@@ -40,4 +40,8 @@ pub struct EnvVar {
 
     // optional token mapping base url
     pub token_mapping_base_url: Option<String>,
+
+    // optional private zkp server settings
+    pub private_zkp_server_max_retires: Option<usize>,
+    pub private_zkp_server_retry_interval: Option<u64>,
 }

--- a/wasm/js-test/src/setup.ts
+++ b/wasm/js-test/src/setup.ts
@@ -1,4 +1,4 @@
-import { bool, cleanEnv, num, str, url } from 'envalid';
+import { bool, cleanEnv, num, str, url, } from 'envalid';
 import { Config, } from '../pkg/intmax2_wasm_lib';
 import * as dotenv from 'dotenv';
 dotenv.config();
@@ -39,6 +39,10 @@ export const env = cleanEnv(process.env, {
     ROLLUP_CONTRACT_ADDRESS: str(),
     ROLLUP_CONTRACT_DEPLOYED_BLOCK_NUMBER: num(),
     WITHDRAWAL_CONTRACT_ADDRESS: str(),
+
+    // Private ZKP server configurations
+    PRIVATE_ZKP_SERVER_MAX_RETRIES: num({ default: 30 }),
+    PRIVATE_ZKP_SERVER_RETRY_INTERVAL: num({ default: 5 }),
 });
 
 export const config = new Config(
@@ -63,4 +67,6 @@ export const config = new Config(
     env.WITHDRAWAL_CONTRACT_ADDRESS,
     env.USE_PRIVATE_ZKP_SERVER,
     env.USE_S3,
+    env.PRIVATE_ZKP_SERVER_MAX_RETRIES,
+    BigInt(env.PRIVATE_ZKP_SERVER_RETRY_INTERVAL),
 );


### PR DESCRIPTION
In this PR, you will be able to specify max retries and retry interval via following env.

`PRIVATE_ZKP_SERVER_MAX_RETRIES`
`PRIVATE_ZKP_SERVER_RETRY_INTERVAL`