### PR TITLE
Fixed missing pubkey in store-vault/s3-store-vault authentication signatures

### DIFF
--- a/interfaces/src/api/s3_store_vault/types.rs
+++ b/interfaces/src/api/s3_store_vault/types.rs
@@ -120,7 +120,11 @@ pub struct S3GetDataBatchRequest {
 impl Signable for S3GetDataBatchRequest {
     fn content(&self) -> Vec<u8> {
         // to reuse the signature, we exclude topic and digests from the content intentionally
-        content_prefix("get_data_batch")
+        [
+            content_prefix("get_data_batch"),
+            bincode::serialize(&self.pubkey).unwrap(),
+        ]
+        .concat()
     }
 }
 
@@ -141,7 +145,11 @@ pub struct S3GetDataSequenceRequest {
 impl Signable for S3GetDataSequenceRequest {
     fn content(&self) -> Vec<u8> {
         // to reuse the signature, we exclude topic and cursor from the content intentionally
-        content_prefix("get_data_sequence")
+        [
+            content_prefix("get_data_sequence"),
+            bincode::serialize(&self.pubkey).unwrap(),
+        ]
+        .concat()
     }
 }
 

--- a/interfaces/src/api/store_vault_server/types.rs
+++ b/interfaces/src/api/store_vault_server/types.rs
@@ -94,8 +94,12 @@ pub struct GetDataBatchRequest {
 
 impl Signable for GetDataBatchRequest {
     fn content(&self) -> Vec<u8> {
-        // to reuse the signature, we exclude data_type and uuids from the content intentionally
-        content_prefix("get_data_batch")
+        // to reuse the signature, we exclude topic and digests from the content intentionally
+        [
+            content_prefix("get_data_batch"),
+            bincode::serialize(&self.pubkey).unwrap(),
+        ]
+        .concat()
     }
 }
 
@@ -115,8 +119,12 @@ pub struct GetDataSequenceRequest {
 
 impl Signable for GetDataSequenceRequest {
     fn content(&self) -> Vec<u8> {
-        // to reuse the signature, we exclude data_type and cursor from the content intentionally
-        content_prefix("get_data_sequence")
+        // to reuse the signature, we exclude topic and cursor from the content intentionally
+        [
+            content_prefix("get_data_sequence"),
+            bincode::serialize(&self.pubkey).unwrap(),
+        ]
+        .concat()
     }
 }
 


### PR DESCRIPTION
This PR fixes a bug where the public key was not included in the authentication signatures for store-vault/s3-store-vault, which could lead to authentication failures.