### PR TITLE
Feat: transfer receipt

### DIFF
--- a/client-sdk/src/client/client.rs
+++ b/client-sdk/src/client/client.rs
@@ -38,7 +38,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     client::{
-        fee_payment::generate_withdrawal_transfers,
+        fee_payment::generate_withdrawal_transfers, receipt::generate_transfer_receipt,
         strategy::mining::validate_mining_deposit_criteria, sync::utils::generate_salt,
     },
     external_api::{
@@ -57,6 +57,7 @@ use super::{
     fee_proof::{generate_fee_proof, quote_transfer_fee},
     history::{fetch_deposit_history, fetch_transfer_history, fetch_tx_history, HistoryEntry},
     misc::payment_memo::PaymentMemo,
+    receipt::validate_transfer_receipt,
     strategy::{
         mining::{fetch_mining_info, Mining},
         tx_status::{get_tx_status, TxStatus},
@@ -747,6 +748,23 @@ impl Client {
         )
         .await?;
         Ok(withdrawal_transfers)
+    }
+
+    pub async fn generate_transfer_receipt(
+        &self,
+        key: KeySet,
+        transfer_digest: Bytes32,
+        receiver: U256,
+    ) -> Result<String, ClientError> {
+        generate_transfer_receipt(self, key, transfer_digest, receiver).await
+    }
+
+    pub async fn validate_transfer_receipt(
+        &self,
+        key: KeySet,
+        transfer_receipt: &str,
+    ) -> Result<TransferData, ClientError> {
+        validate_transfer_receipt(self, key, transfer_receipt).await
     }
 }
 

--- a/client-sdk/src/client/error.rs
+++ b/client-sdk/src/client/error.rs
@@ -5,7 +5,10 @@ use intmax2_interfaces::{
 
 use crate::external_api::contract::error::BlockchainError;
 
-use super::{strategy::error::StrategyError, sync::error::SyncError};
+use super::{
+    receive_validation::ReceiveValidationError, strategy::error::StrategyError,
+    sync::error::SyncError,
+};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ClientError {
@@ -15,11 +18,14 @@ pub enum ClientError {
     #[error("Blockchain error: {0}")]
     BlockchainError(#[from] BlockchainError),
 
-    #[error("Strategy error: {0}")]
+    #[error(transparent)]
     StrategyError(#[from] StrategyError),
 
-    #[error("Sync error: {0}")]
+    #[error(transparent)]
     SyncError(#[from] SyncError),
+
+    #[error(transparent)]
+    ReceiveValidationError(#[from] ReceiveValidationError),
 
     #[error("Proof compression error: {0}")]
     ProofCompressionError(#[from] ProofCompressionError),
@@ -56,4 +62,7 @@ pub enum ClientError {
 
     #[error("Unexpected error: {0}")]
     UnexpectedError(String),
+
+    #[error("Deserialization error: {0}")]
+    DeserializeError(String),
 }

--- a/client-sdk/src/client/mod.rs
+++ b/client-sdk/src/client/mod.rs
@@ -8,6 +8,7 @@ pub mod history;
 pub mod key_from_eth;
 pub mod misc;
 pub mod multisig;
+pub mod receipt;
 pub mod receive_validation;
 pub mod strategy;
 pub mod sync;

--- a/client-sdk/src/client/receipt.rs
+++ b/client-sdk/src/client/receipt.rs
@@ -60,5 +60,5 @@ pub async fn validate_transfer_receipt(
         &transfer_receipt.data,
     )
     .await?;
-    todo!()
+    Ok(transfer_receipt.data.clone())
 }

--- a/client-sdk/src/client/receipt.rs
+++ b/client-sdk/src/client/receipt.rs
@@ -1,0 +1,64 @@
+use base64::{prelude::BASE64_STANDARD, Engine};
+use intmax2_interfaces::data::{
+    data_type::DataType, encryption::BlsEncryption, meta_data::MetaData,
+    transfer_data::TransferData,
+};
+use intmax2_zkp::{
+    common::signature_content::key_set::KeySet,
+    ethereum_types::{bytes32::Bytes32, u256::U256},
+};
+use serde::{Deserialize, Serialize};
+
+use crate::client::receive_validation::validate_receive;
+
+use super::{client::Client, error::ClientError, strategy::common::fetch_single_data};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TransferReceipt {
+    pub data: TransferData,
+    pub meta: MetaData,
+}
+
+impl BlsEncryption for TransferReceipt {}
+
+pub async fn generate_transfer_receipt(
+    client: &Client,
+    key: KeySet,
+    transfer_digest: Bytes32,
+    receiver: U256,
+) -> Result<String, ClientError> {
+    let (meta, data) = fetch_single_data(
+        client.store_vault_server.as_ref(),
+        key,
+        DataType::Transfer,
+        transfer_digest,
+    )
+    .await?;
+    let encrypted_data = TransferReceipt { data, meta }.encrypt(receiver, None)?;
+    let encrypted_data_base64 = BASE64_STANDARD.encode(&encrypted_data);
+    Ok(encrypted_data_base64)
+}
+
+pub async fn validate_transfer_receipt(
+    client: &Client,
+    key: KeySet,
+    transfer_receipt: &str,
+) -> Result<TransferData, ClientError> {
+    let encrypted_data = BASE64_STANDARD.decode(transfer_receipt).map_err(|e| {
+        ClientError::DeserializeError(format!(
+            "Failed to decode transfer receipt as base64: {}",
+            e
+        ))
+    })?;
+    let transfer_receipt: TransferReceipt = TransferReceipt::decrypt(key, None, &encrypted_data)?;
+    validate_receive(
+        client.store_vault_server.as_ref(),
+        client.validity_prover.as_ref(),
+        key.pubkey,
+        &transfer_receipt.meta,
+        &transfer_receipt.data,
+    )
+    .await?;
+    todo!()
+}

--- a/interfaces/src/data/encryption/bls/v1/message.rs
+++ b/interfaces/src/data/encryption/bls/v1/message.rs
@@ -102,8 +102,6 @@ impl<'a> EncryptedMessage<'a> {
         // perform ECDH to get the shared secret, using the remote public key from the message and
         // the given secret key
         let x = ecdh_x(&self.public_key, secret_key);
-        println!("ecdh: {:?}", x.to_hex());
-
         self.derive_keys_with_ecdh(x)
     }
 

--- a/wasm/js-test/src/receipt.ts
+++ b/wasm/js-test/src/receipt.ts
@@ -1,0 +1,37 @@
+import { fetch_transfer_history, generate_intmax_account_from_eth_key, generate_transfer_receipt, get_derive_path_list, JsDerive, JsMetaDataCursor, save_derive_path, validate_transfer_receipt, } from '../pkg';
+import { env, config } from './setup';
+
+async function main() {
+    const ethKey = env.USER_ETH_PRIVATE_KEY;
+    const key = await generate_intmax_account_from_eth_key(ethKey);
+    const privkey = key.privkey;
+    console.log(`privkey`, privkey);
+    console.log(`pubkey`, key.pubkey);
+
+    const cursor = new JsMetaDataCursor(null, "asc", null);
+    const transfer_history = await fetch_transfer_history(config, key.privkey, cursor);
+    if (transfer_history.history.length === 0) {
+        console.log("No transfer history found");
+        return;
+    }
+    const transfer_data = transfer_history.history[0].data;
+    const transfer_digest = transfer_history.history[0].meta.digest;
+    const recipient = transfer_data.transfer.recipient.data;
+    console.log(`transfer_digest: ${transfer_digest}`);
+    console.log(`recipient: ${recipient}`);
+
+    const receipt = await generate_transfer_receipt(config, key.privkey, transfer_digest, recipient);
+    console.log(`size of receipt: ${receipt.length}`);
+
+    // verify the receipt
+    const recovered_transfer_data = await validate_transfer_receipt(config, key.privkey, receipt)
+    console.log(`recovered transfer amount: ${recovered_transfer_data.transfer.amount}`);
+}
+
+
+main().then(() => {
+    process.exit(0);
+}).catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -8,7 +8,7 @@ use intmax2_zkp::{
 };
 use js_types::{
     common::{JsClaimInfo, JsMining, JsTransfer, JsWithdrawalInfo},
-    data::{JsDepositResult, JsTxResult, JsUserData},
+    data::{JsDepositResult, JsTransferData, JsTxResult, JsUserData},
     fee::{JsFee, JsFeeQuote},
     payment_memo::JsPaymentMemoEntry,
     utils::{parse_address, parse_bytes32, parse_u256},
@@ -347,6 +347,39 @@ pub async fn quote_claim_fee(config: &Config, fee_token_index: u32) -> Result<Js
     let client = get_client(config);
     let fee_quote = client.quote_claim_fee(fee_token_index).await?;
     Ok(fee_quote.into())
+}
+
+#[wasm_bindgen]
+pub async fn generate_transfer_receipt(
+    config: &Config,
+    private_key: &str,
+    transfer_digest: &str,
+    receiver: &str,
+) -> Result<String, JsError> {
+    init_logger();
+    let key = str_privkey_to_keyset(private_key)?;
+    let transfer_digest = parse_bytes32(transfer_digest)?;
+    let receiver = parse_h256_as_u256(receiver)?;
+    let client = get_client(config);
+    let receipt = client
+        .generate_transfer_receipt(key, transfer_digest, receiver)
+        .await?;
+    Ok(receipt)
+}
+
+#[wasm_bindgen]
+pub async fn validate_transfer_receipt(
+    config: &Config,
+    private_key: &str,
+    transfer_receipt: &str,
+) -> Result<JsTransferData, JsError> {
+    init_logger();
+    let key = str_privkey_to_keyset(private_key)?;
+    let client = get_client(config);
+    let transfer_data = client
+        .validate_transfer_receipt(key, transfer_receipt)
+        .await?;
+    Ok(transfer_data.into())
 }
 
 fn init_logger() {


### PR DESCRIPTION
Added transfer receipt (proof of transfer) and a function to verify the transfer receipt to the WASM.

Example for TS: 
https://github.com/InternetMaximalism/intmax2/blob/f5644e181f1846cba0eda96931bf283dd29d0836/wasm/js-test/src/receipt.ts#L4