### PR TITLE
change log-level of db from info to debug

### DIFF
--- a/server-common/src/db.rs
+++ b/server-common/src/db.rs
@@ -59,7 +59,7 @@ impl<'c> Executor<'c> for &'c TracingPool {
         Q: Send + 'q + sqlx::Execute<'q, Self::Database>,
     {
         let operation = sql_summary(&query);
-        let _span = tracing::info_span!(
+        let _span = tracing::debug_span!(
             "db",
             "operation" = operation,
             "otel.name" = %format!("DB: {}", operation),
@@ -75,7 +75,7 @@ impl<'c> Executor<'c> for &'c TracingPool {
         E: 'q + Send + Execute<'q, Self::Database>,
     {
         let operation = sql_summary(&query);
-        let _span = tracing::info_span!(
+        let _span = tracing::debug_span!(
             "db",
             "operation" = operation,
             "otel.name" = %format!("DB: {}", operation),
@@ -94,7 +94,7 @@ impl<'c> Executor<'c> for &'c TracingPool {
         E: 'q + Send + Execute<'q, Self::Database>,
     {
         let operation = sql_summary(&query);
-        let _span = tracing::info_span!(
+        let _span = tracing::debug_span!(
             "db",
             "operation" = operation,
             "otel.name" = %format!("DB: {}", operation),
@@ -137,7 +137,7 @@ impl<'c> Executor<'c> for TracingPool {
         Q: Send + 'q + sqlx::Execute<'q, Self::Database>,
     {
         let operation = sql_summary(&query);
-        let _span = tracing::info_span!(
+        let _span = tracing::debug_span!(
             "db",
             "operation" = operation,
             "otel.name" = %format!("DB: {}", operation),
@@ -153,7 +153,7 @@ impl<'c> Executor<'c> for TracingPool {
         E: 'q + Send + Execute<'q, Self::Database>,
     {
         let operation = sql_summary(&query);
-        let _span = tracing::info_span!(
+        let _span = tracing::debug_span!(
             "db",
             "operation" = operation,
             "otel.name" = %format!("DB: {}", operation),
@@ -172,7 +172,7 @@ impl<'c> Executor<'c> for TracingPool {
         E: 'q + Send + Execute<'q, Self::Database>,
     {
         let operation = sql_summary(&query);
-        let _span = tracing::info_span!(
+        let _span = tracing::debug_span!(
             "db",
             "operation" = operation,
             "otel.name" = %format!("DB: {}", operation),


### PR DESCRIPTION
The validity prover is generating too many logs, so we should change the database logging level from info to debug to reduce the log volume.