### PR TITLE
Add ECDH share validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3915,6 +3915,7 @@ dependencies = [
  "ark-bn254",
  "ark-ec",
  "ark-ff 0.5.0",
+ "ark-serialize 0.4.2",
  "ark-std 0.5.0",
  "async-trait",
  "bincode",

--- a/interfaces/Cargo.toml
+++ b/interfaces/Cargo.toml
@@ -35,6 +35,7 @@ log = { version = "0.4.14", default-features = false }                          
 plonky2_u32 = { git = "https://github.com/InternetMaximalism/plonky2-u32.git", branch = "intmax2-dev" }
 aes-gcm = "0.10.3"
 rsa = "0.9.8"
+ark-serialize = "0.4.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3"

--- a/interfaces/src/data/encryption/bls/v1/algorithm.rs
+++ b/interfaces/src/data/encryption/bls/v1/algorithm.rs
@@ -67,7 +67,7 @@ impl EciesSender {
         let mut rng = rand::thread_rng();
         let key = KeySet::rand(&mut rng);
         let receiver_public_key = self.receiver_public_key;
-        let x = ecdh_x(&receiver_public_key, &key.privkey_fr());
+        let x = ecdh_x(&receiver_public_key, &key.privkey);
 
         out.reserve(U256_SIZE + 16 + data.len() + 32);
 
@@ -115,7 +115,7 @@ impl EciesReceiver {
         let encrypted_message = EncryptedMessage::parse(data)?;
 
         // derive keys from the secret key and the encrypted message
-        let keys = encrypted_message.derive_keys(&self.key.privkey_fr());
+        let keys = encrypted_message.derive_keys(&self.key.privkey);
 
         // check message integrity and decrypt the message
         encrypted_message.check_and_decrypt(keys)
@@ -176,7 +176,7 @@ mod test {
         let key = KeySet::rand(&mut rng);
         out.extend_from_slice(&key.pubkey.to_bytes_be()); // 32 bytes
 
-        let x = ecdh_x(&receiver_public_key, &key.privkey_fr());
+        let x = ecdh_x(&receiver_public_key, &key.privkey);
         let mut key = [0u8; 32];
         kdf(x, &[], &mut key);
 

--- a/interfaces/src/data/encryption/bls/v1/chaum_pedersen.rs
+++ b/interfaces/src/data/encryption/bls/v1/chaum_pedersen.rs
@@ -1,0 +1,141 @@
+use ark_bn254::{Fr, G1Affine};
+use ark_ec::{AffineRepr, CurveGroup};
+use ark_ff::{UniformRand, Zero};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use ark_std::{ops::Mul, rand::Rng};
+use intmax2_zkp::{common::signature_content::key_set::KeySet, ethereum_types::u256::U256};
+use plonky2_bn254::fields::recover::RecoverFromX;
+use sha2::{Digest, Sha256};
+
+type Scalar = Fr;
+
+/// Zero-knowledge proof of correct partial decryption (Chaum-Pedersen proof)
+#[derive(Clone, Debug, CanonicalSerialize, CanonicalDeserialize)]
+pub struct ZKProof {
+    /// The commitment a = g^v
+    pub a: G1Affine,
+    /// The commitment b = C1^v
+    pub b: G1Affine,
+    /// The challenge response z = v - c*xi
+    pub z: Scalar,
+}
+
+/// Convert a hash digest to a scalar field element
+fn hash_to_scalar(hash: &[u8]) -> Scalar {
+    // Take first 32 bytes of hash and interpret as Scalar
+    // Note: This is a simplified approach for demonstration
+    let mut repr = [0u8; 32];
+    repr.copy_from_slice(&hash[0..32]);
+
+    // Convert to scalar (mod order of scalar field)
+    let mut acc = Scalar::zero();
+    for byte in repr.iter() {
+        acc = acc * Scalar::from(256u64) + Scalar::from(*byte as u64);
+    }
+    acc
+}
+
+/// Compute challenge for Chaum-Pedersen proof
+fn compute_challenge(
+    g: &G1Affine,
+    c1: &G1Affine,
+    pk_i: &G1Affine,
+    di: &G1Affine,
+    a: &G1Affine,
+    b: &G1Affine,
+) -> Scalar {
+    let mut hasher = Sha256::new();
+
+    // Hash all values in the proof
+    let mut buf = Vec::new();
+    g.serialize_uncompressed(&mut buf).unwrap();
+    hasher.update(&buf);
+
+    buf.clear();
+    c1.serialize_uncompressed(&mut buf).unwrap();
+    hasher.update(&buf);
+
+    buf.clear();
+    pk_i.serialize_uncompressed(&mut buf).unwrap();
+    hasher.update(&buf);
+
+    buf.clear();
+    di.serialize_uncompressed(&mut buf).unwrap();
+    hasher.update(&buf);
+
+    buf.clear();
+    a.serialize_uncompressed(&mut buf).unwrap();
+    hasher.update(&buf);
+
+    buf.clear();
+    b.serialize_uncompressed(&mut buf).unwrap();
+    hasher.update(&buf);
+
+    // Convert hash output to scalar
+    let hash = hasher.finalize();
+    hash_to_scalar(&hash)
+}
+
+pub fn partial_decrypt_with_proof<R: Rng>(
+    remote_public_key_x: &U256,
+    secret_key: &U256,
+    rng: &mut R,
+) -> (G1Affine, ZKProof) {
+    let share = KeySet::new(*secret_key);
+    let c1 = G1Affine::recover_from_x((*remote_public_key_x).into());
+
+    // Calculate Di = C1^xi
+    let xi = share.privkey_fr();
+    let di = c1.mul(xi).into_affine();
+
+    // Generator point
+    let g = G1Affine::generator();
+
+    // Generate Chaum-Pedersen proof that log_g(PKi) = log_C1(Di)
+    // Choose random v
+    let v = Scalar::rand(rng);
+
+    // Compute commitments
+    let a = g.mul(v).into_affine();
+    let b = c1.mul(v).into_affine();
+
+    // Compute challenge c = Hash(g, C1, PKi, Di, a, b)
+    let pk_i = G1Affine::recover_from_x(share.pubkey.into());
+    let c = compute_challenge(&g, &c1, &pk_i, &di, &a, &b);
+
+    // Compute response z = v - c * xi
+    let z = v - c * xi;
+
+    let proof = ZKProof { a, b, z };
+
+    (di, proof)
+}
+
+/// Verify a partial decryption share using its zero-knowledge proof
+pub fn verify_share(
+    pk_share: U256,
+    remote_public_key_x: U256,
+    di: &G1Affine,
+    proof: &ZKProof,
+) -> bool {
+    // Generator point
+    let g = G1Affine::generator();
+
+    // Recompute challenge c = Hash(g, C1, PKi, Di, a, b)
+    let c1 = G1Affine::recover_from_x(remote_public_key_x.into());
+    let pk_i = G1Affine::recover_from_x(pk_share.into());
+    let c = compute_challenge(&g, &c1, &pk_i, di, &proof.a, &proof.b);
+
+    // Verify g^z * PKi^c = a
+    let g_z = g.mul(proof.z);
+    let pk_i_c = pk_i.mul(c);
+    let left1 = (g_z + pk_i_c).into_affine();
+
+    // Verify C1^z * Di^c = b
+    let c1_z = c1.mul(proof.z);
+    let di_c = di.mul(c);
+    let left2 = (c1_z + di_c).into_affine();
+
+    // Check if both equations hold
+    left1 == proof.a && left2 == proof.b
+}

--- a/interfaces/src/data/encryption/bls/v1/message.rs
+++ b/interfaces/src/data/encryption/bls/v1/message.rs
@@ -6,7 +6,6 @@ use aes::{
     Aes128,
 };
 use alloy_primitives::{B128, B256};
-use ark_bn254::Fr;
 use ctr::Ctr64BE;
 use intmax2_zkp::ethereum_types::{u256::U256, u32limb_trait::U32LimbTrait};
 
@@ -35,7 +34,7 @@ pub struct EncryptedMessage<'a> {
     ///
     /// See source comments of [`Self::check_integrity`] for more information.
     auth_data: [u8; 2],
-    /// The remote secp256k1 public key
+    /// The remote public key
     public_key: U256,
     /// The IV, for use in AES during decryption, in the tag check
     iv: B128,
@@ -98,7 +97,7 @@ impl<'a> EncryptedMessage<'a> {
 
     /// Use the given secret and this encrypted message to derive the shared secret, and use the
     /// shared secret to derive the mac and encryption keys.
-    pub fn derive_keys(&self, secret_key: &Fr) -> RLPxSymmetricKeys {
+    pub fn derive_keys(&self, secret_key: &U256) -> RLPxSymmetricKeys {
         // perform ECDH to get the shared secret, using the remote public key from the message and
         // the given secret key
         let x = ecdh_x(&self.public_key, secret_key);

--- a/interfaces/src/data/encryption/bls/v1/mod.rs
+++ b/interfaces/src/data/encryption/bls/v1/mod.rs
@@ -1,4 +1,5 @@
 pub mod algorithm;
+pub mod chaum_pedersen;
 pub mod error;
 pub mod message;
 pub mod multisig;

--- a/interfaces/src/data/encryption/bls/v1/utils.rs
+++ b/interfaces/src/data/encryption/bls/v1/utils.rs
@@ -3,11 +3,14 @@
 //! <https://github.com/paradigmxyz/reth/blob/main/crates/net/ecies/src/util.rs>
 
 use alloy_primitives::B256;
-use ark_bn254::{g1::G1Affine, Fr, G1Projective};
+use ark_bn254::{g1::G1Affine, G1Projective};
 use ark_ec::{AffineRepr, CurveGroup};
-use ark_std::Zero;
+use ark_std::{ops::Mul, Zero};
 use hmac::{Hmac, Mac};
-use intmax2_zkp::ethereum_types::{u256::U256, u32limb_trait::U32LimbTrait};
+use intmax2_zkp::{
+    common::signature_content::key_set::KeySet,
+    ethereum_types::{u256::U256, u32limb_trait::U32LimbTrait},
+};
 use plonky2_bn254::fields::{recover::RecoverFromX, sgn::Sgn};
 use sha2::{Digest, Sha256};
 use std::ops::Neg;
@@ -27,27 +30,29 @@ pub(crate) fn hmac_sha256(key: &[u8], input: &[&[u8]], auth_data: &[u8]) -> B256
     B256::from_slice(&hmac.finalize().into_bytes())
 }
 
-pub(crate) fn ecdh_xy(remote_public_key_x: &U256, secret_key: &Fr) -> (U256, bool) {
-    let pubkey_x = *remote_public_key_x;
-    let pubkey_g1 = G1Affine::recover_from_x(pubkey_x.into());
-    let ecdh_key = G1Affine::from(pubkey_g1 * secret_key);
+pub(crate) fn ecdh_xy(remote_public_key_x: &U256, secret_key: &U256) -> G1Affine {
+    let share = KeySet::new(*secret_key);
+    let c1 = G1Affine::recover_from_x((*remote_public_key_x).into());
+    let xi = share.privkey_fr();
 
-    (U256::from(*ecdh_key.x().unwrap()), ecdh_key.y.sgn())
+    // C1^xi
+    c1.mul(xi).into_affine()
 }
 
-pub(crate) fn ecdh_x(remote_public_key_x: &U256, secret_key: &Fr) -> U256 {
-    ecdh_xy(remote_public_key_x, secret_key).0
+pub(crate) fn ecdh_x(remote_public_key_x: &U256, secret_key: &U256) -> U256 {
+    let ecdh_key = ecdh_xy(remote_public_key_x, secret_key);
+
+    U256::from(*ecdh_key.x().unwrap())
 }
 
-pub(crate) fn aggregate_ecdh_x(ecdh_shares_xy: &[(U256, bool)]) -> U256 {
+pub(crate) fn aggregate_ecdh_x(ecdh_shares_xy: &[G1Affine]) -> U256 {
     if ecdh_shares_xy.is_empty() {
         panic!("ecdh_shares is empty");
     }
 
     let mut ecdh_share = G1Projective::zero();
-    for (share, y_parity) in ecdh_shares_xy {
-        let point = G1Affine::recover_from_x((*share).into());
-        ecdh_share += if *y_parity { point.neg() } else { point };
+    for point in ecdh_shares_xy {
+        ecdh_share += point;
     }
 
     U256::from(ecdh_share.into_affine().x)
@@ -56,4 +61,17 @@ pub(crate) fn aggregate_ecdh_x(ecdh_shares_xy: &[(U256, bool)]) -> U256 {
 pub(crate) fn kdf(secret: U256, s1: &[u8], dest: &mut [u8]) {
     let secret: Vec<u8> = secret.to_bytes_be();
     concat_kdf::derive_key_into::<Sha256>(&secret, s1, dest).unwrap();
+}
+
+pub fn g1_point_to_xy(point: G1Affine) -> (U256, bool) {
+    (U256::from(*point.x().unwrap()), point.y.sgn())
+}
+
+pub fn xy_to_g1_point(x: U256, y_parity: bool) -> G1Affine {
+    let point_without_sign = G1Affine::recover_from_x(x.into());
+    if y_parity {
+        point_without_sign.neg()
+    } else {
+        point_without_sign
+    }
 }


### PR DESCRIPTION
When decrypting data encrypted using a multisig address, verify that the partial decryption key received from another party can only be generated by that specific individual.
The submitter of each share attaches a Chaum–Pedersen proof, and the aggregator of the shares verifies it.