### PR TITLE
Added tests for block_builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,6 +139,7 @@ version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24eda4e2a6e042aa4e55ac438a2ae052d3b5da0ecf83d7411e1a368946925208"
 dependencies = [
+ "actix-macros",
  "futures-core",
  "tokio",
 ]
@@ -1399,6 +1400,7 @@ name = "block-builder"
 version = "0.1.21"
 dependencies = [
  "actix-cors",
+ "actix-rt",
  "actix-web",
  "anyhow",
  "async-trait",
@@ -1412,7 +1414,9 @@ dependencies = [
  "intmax2-interfaces",
  "intmax2-zkp",
  "log",
+ "mockall",
  "num-bigint 0.4.6",
+ "num-traits",
  "plonky2",
  "plonky2_bn254",
  "redis 0.29.1",
@@ -1424,6 +1428,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tracing-actix-web",
+ "url",
  "uuid 1.16.0",
 ]
 

--- a/block-builder/Cargo.toml
+++ b/block-builder/Cargo.toml
@@ -4,34 +4,38 @@ version.workspace = true
 edition = "2021"
 
 [dependencies]
+actix-web = { workspace = true }
+actix-cors = { workspace = true }
 anyhow = { workspace = true }
-plonky2 = { workspace = true }
-plonky2_bn254 = { workspace = true }
-intmax2-zkp = { workspace = true }
-intmax2-client-sdk = { path = "../client-sdk" }
-intmax2-interfaces = { path = "../interfaces" }
-server-common = { path = "../server-common" }
-tokio = { workspace = true }
-reqwest = { workspace = true }
-ethers = { workspace = true }
-serde_json = { workspace = true }
-serde = { workspace = true }
+bincode = { workspace = true }
 chrono = { workspace = true }
-log = { workspace = true }
-uuid = { workspace = true }
 dotenv = { workspace = true }
 envy = { workspace = true }
 env_logger = { workspace = true }
-bincode = { workspace = true }
-thiserror = { workspace = true }
-actix-web = { workspace = true }
-actix-cors = { workspace = true }
-tracing-actix-web = { workspace = true }
+ethers = { workspace = true }
+intmax2-zkp = { workspace = true }
+intmax2-client-sdk = { path = "../client-sdk" }
+intmax2-interfaces = { path = "../interfaces" }
+log = { workspace = true }
+plonky2 = { workspace = true }
+plonky2_bn254 = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 serde_qs = { workspace = true }
+server-common = { path = "../server-common" }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing-actix-web = { workspace = true }
+uuid = { workspace = true }
+async-trait = "0.1.88"
+actix-rt = "2.10.0"
+mockall = "0.13.1"
 num-bigint = "0.4.6"
+num-traits = "0.2.19"
 redis = { version = "0.29.1", features = [
     "aio",
     "connection-manager",
     "tokio-native-tls-comp",
 ] }
-async-trait = "0.1.88"
+url = "2.5.4"

--- a/block-builder/src/api/state.rs
+++ b/block-builder/src/api/state.rs
@@ -1,5 +1,7 @@
+use std::sync::Arc;
+
 use crate::{
-    app::{block_builder::BlockBuilder, error::BlockBuilderError},
+    app::{block_builder::{BlockBuilder, RealEthBalanceProvider}, error::BlockBuilderError},
     EnvVar,
 };
 
@@ -10,11 +12,108 @@ pub struct State {
 
 impl State {
     pub async fn new(env: &EnvVar) -> Result<Self, BlockBuilderError> {
-        let block_builder = BlockBuilder::new(env).await?;
+        let block_builder = BlockBuilder::new(env, Arc::new(RealEthBalanceProvider)).await?;
         Ok(State { block_builder })
     }
 
     pub fn run(&self) {
         self.block_builder.run();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ethers::types::Address;
+    
+    use crate::app::storage::redis_storage::test_helper::{run_redis_docker, stop_redis_docker, find_free_port};
+
+    // Tries to create new State using locally initialized EnvVar
+    #[tokio::test]
+    async fn test_state_new_redis_storage() {
+        let port = find_free_port();
+        let cont_name = "redis-test-state-new-redis-storage";
+
+        // Initialize our own EnvVar
+        let env = EnvVar {
+            port: 9004,
+            block_builder_url: "http://localhost:9004".to_string(),
+            redis_url: Some(format!("redis://localhost:{}", port).to_string()),
+            cluster_id: Some("1".to_string()),
+            l2_rpc_url: "http://localhost:8545".to_string(),
+            l2_chain_id: 1337,
+            rollup_contract_address: Address::zero(),
+            block_builder_registry_contract_address: Address::zero(),
+            store_vault_server_base_url: "http://localhost:9000".to_string(),
+            use_s3: Some(false),
+            validity_prover_base_url: "http://localhost:9100".to_string(),
+            block_builder_private_key: "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d".parse().unwrap(),   // anvil key
+            eth_allowance_for_block: "0.3".to_string(),
+            tx_timeout: 80,
+            accepting_tx_interval: 40,
+            proposing_block_interval: 10,
+            deposit_check_interval: Some(20),
+            initial_heart_beat_delay: 600,
+            gas_limit_for_block_post: Some(40000),
+            heart_beat_interval: 86400,
+            beneficiary_pubkey: None,
+            registration_fee: Some("0:100,1:2000".to_string()),
+            non_registration_fee: Some("0:100,1:2000".to_string()),
+            registration_collateral_fee: None,
+            non_registration_collateral_fee: None,
+        };
+
+        // Run docker image
+        stop_redis_docker(cont_name);
+        let output = run_redis_docker(port, cont_name);
+        assert!(output.status.success(), "Couldn't start {}: {}", cont_name, String::from_utf8_lossy(&output.stderr));
+
+        // Create new State
+        let state = State::new(&env).await;
+        if !state.is_ok() {
+            stop_redis_docker(cont_name);
+            assert!(state.is_ok(), "Couldn't create new State using locally initialized EnvVar");
+        }
+        
+        // Stop docker image
+        let output = stop_redis_docker(cont_name);
+        assert!(output.status.success(), "Couldn't stop {}: {}", cont_name, String::from_utf8_lossy(&output.stderr));
+    }
+
+    // Tries to create new State using locally initialized EnvVar
+    #[tokio::test]
+    async fn test_state_new_memory_storage() {
+        // Initialize our own EnvVar
+        let env = EnvVar {
+            port: 9004,
+            block_builder_url: "http://localhost:9004".to_string(),
+            redis_url: None,
+            cluster_id: Some("1".to_string()),
+            l2_rpc_url: "http://localhost:8545".to_string(),
+            l2_chain_id: 1337,
+            rollup_contract_address: Address::zero(),
+            block_builder_registry_contract_address: Address::zero(),
+            store_vault_server_base_url: "http://localhost:9000".to_string(),
+            use_s3: Some(false),
+            validity_prover_base_url: "http://localhost:9100".to_string(),
+            block_builder_private_key: "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d".parse().unwrap(),   // anvil key
+            eth_allowance_for_block: "0.3".to_string(),
+            tx_timeout: 80,
+            accepting_tx_interval: 40,
+            proposing_block_interval: 10,
+            deposit_check_interval: Some(20),
+            initial_heart_beat_delay: 600,
+            gas_limit_for_block_post: Some(40000),
+            heart_beat_interval: 86400,
+            beneficiary_pubkey: None,
+            registration_fee: Some("0:100,1:2000".to_string()),
+            non_registration_fee: Some("0:100,1:2000".to_string()),
+            registration_collateral_fee: None,
+            non_registration_collateral_fee: None,
+        };
+
+        // Create new State
+        let state = State::new(&env).await;
+        assert!(state.is_ok(), "Couldn't create new State with an empty Redis url");
     }
 }

--- a/block-builder/src/api/state.rs
+++ b/block-builder/src/api/state.rs
@@ -1,7 +1,10 @@
 use std::sync::Arc;
 
 use crate::{
-    app::{block_builder::{BlockBuilder, RealEthBalanceProvider}, error::BlockBuilderError},
+    app::{
+        block_builder::{BlockBuilder, RealEthBalanceProvider},
+        error::BlockBuilderError,
+    },
     EnvVar,
 };
 
@@ -25,8 +28,10 @@ impl State {
 mod tests {
     use super::*;
     use ethers::types::Address;
-    
-    use crate::app::storage::redis_storage::test_helper::{run_redis_docker, stop_redis_docker, find_free_port};
+
+    use crate::app::storage::redis_storage::test_helper::{
+        find_free_port, run_redis_docker, stop_redis_docker,
+    };
 
     // Tries to create new State using locally initialized EnvVar
     #[tokio::test]
@@ -47,7 +52,10 @@ mod tests {
             store_vault_server_base_url: "http://localhost:9000".to_string(),
             use_s3: Some(false),
             validity_prover_base_url: "http://localhost:9100".to_string(),
-            block_builder_private_key: "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d".parse().unwrap(),   // anvil key
+            block_builder_private_key:
+                "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+                    .parse()
+                    .unwrap(), // anvil key
             eth_allowance_for_block: "0.3".to_string(),
             tx_timeout: 80,
             accepting_tx_interval: 40,
@@ -66,18 +74,31 @@ mod tests {
         // Run docker image
         stop_redis_docker(cont_name);
         let output = run_redis_docker(port, cont_name);
-        assert!(output.status.success(), "Couldn't start {}: {}", cont_name, String::from_utf8_lossy(&output.stderr));
+        assert!(
+            output.status.success(),
+            "Couldn't start {}: {}",
+            cont_name,
+            String::from_utf8_lossy(&output.stderr)
+        );
 
         // Create new State
         let state = State::new(&env).await;
         if !state.is_ok() {
             stop_redis_docker(cont_name);
-            assert!(state.is_ok(), "Couldn't create new State using locally initialized EnvVar");
+            assert!(
+                state.is_ok(),
+                "Couldn't create new State using locally initialized EnvVar"
+            );
         }
-        
+
         // Stop docker image
         let output = stop_redis_docker(cont_name);
-        assert!(output.status.success(), "Couldn't stop {}: {}", cont_name, String::from_utf8_lossy(&output.stderr));
+        assert!(
+            output.status.success(),
+            "Couldn't stop {}: {}",
+            cont_name,
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 
     // Tries to create new State using locally initialized EnvVar
@@ -96,7 +117,10 @@ mod tests {
             store_vault_server_base_url: "http://localhost:9000".to_string(),
             use_s3: Some(false),
             validity_prover_base_url: "http://localhost:9100".to_string(),
-            block_builder_private_key: "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d".parse().unwrap(),   // anvil key
+            block_builder_private_key:
+                "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+                    .parse()
+                    .unwrap(), // anvil key
             eth_allowance_for_block: "0.3".to_string(),
             tx_timeout: 80,
             accepting_tx_interval: 40,
@@ -114,6 +138,9 @@ mod tests {
 
         // Create new State
         let state = State::new(&env).await;
-        assert!(state.is_ok(), "Couldn't create new State with an empty Redis url");
+        assert!(
+            state.is_ok(),
+            "Couldn't create new State with an empty Redis url"
+        );
     }
 }

--- a/block-builder/src/app/block_builder.rs
+++ b/block-builder/src/app/block_builder.rs
@@ -265,7 +265,7 @@ impl BlockBuilder {
         let rpc_url = self.registry_contract.rpc_url.clone();
         let block_builder_address =
             ethers::types::Address::from_slice(&self.config.block_builder_address.to_bytes_be());
-        let balance = get_eth_balance(&rpc_url, block_builder_address)
+        let balance = self.balance_provider.get_eth_balance(&rpc_url, block_builder_address)
             .await
             .map_err(|e| {
                 BlockBuilderError::BlockChainHealthError(format!(

--- a/block-builder/src/app/block_builder.rs
+++ b/block-builder/src/app/block_builder.rs
@@ -265,7 +265,9 @@ impl BlockBuilder {
         let rpc_url = self.registry_contract.rpc_url.clone();
         let block_builder_address =
             ethers::types::Address::from_slice(&self.config.block_builder_address.to_bytes_be());
-        let balance = self.balance_provider.get_eth_balance(&rpc_url, block_builder_address)
+        let balance = self
+            .balance_provider
+            .get_eth_balance(&rpc_url, block_builder_address)
             .await
             .map_err(|e| {
                 BlockBuilderError::BlockChainHealthError(format!(

--- a/block-builder/src/app/block_builder.rs
+++ b/block-builder/src/app/block_builder.rs
@@ -4,6 +4,7 @@ use intmax2_client_sdk::{
     external_api::{
         contract::{
             block_builder_registry::BlockBuilderRegistryContract,
+            error::BlockchainError,
             rollup_contract::RollupContract,
             utils::{get_address, get_eth_balance},
         },
@@ -63,6 +64,20 @@ pub struct Config {
     pub non_registration_collateral_fee: Option<HashMap<u32, U256>>,
 }
 
+#[async_trait::async_trait]
+pub trait EthBalanceProvider: Send + Sync {
+    async fn get_eth_balance(&self, rpc_url: &str, address: ethers::types::Address) -> Result<ethers::types::U256, BlockchainError>;
+}
+
+pub struct RealEthBalanceProvider;
+
+#[async_trait::async_trait]
+impl EthBalanceProvider for RealEthBalanceProvider {
+    async fn get_eth_balance(&self, rpc_url: &str, address: ethers::types::Address) -> Result<ethers::types::U256, BlockchainError> {
+        get_eth_balance(rpc_url, address).await
+    }
+}
+
 #[derive(Clone)]
 pub struct BlockBuilder {
     pub config: Config,
@@ -72,11 +87,12 @@ pub struct BlockBuilder {
     pub registry_contract: BlockBuilderRegistryContract,
 
     pub storage: Arc<Box<dyn Storage>>,
+    pub balance_provider: Arc<dyn EthBalanceProvider>,
 }
 
 impl BlockBuilder {
     /// Create a new BlockBuilder instance
-    pub async fn new(env: &EnvVar) -> Result<Self, BlockBuilderError> {
+    pub async fn new(env: &EnvVar, balance_provider: Arc<dyn EthBalanceProvider>) -> Result<Self, BlockBuilderError> {
         // Initialize clients
         let store_vault_server_client: Arc<Box<dyn StoreVaultClientInterface>> =
             if env.use_s3.unwrap_or(true) {
@@ -111,6 +127,7 @@ impl BlockBuilder {
             rollup_contract,
             registry_contract,
             storage,
+            balance_provider,
         })
     }
 
@@ -373,4 +390,185 @@ fn convert_u256_from_ether_to_intmax(
     let mut buf = [0u8; 32];
     u.to_big_endian(&mut buf);
     intmax2_zkp::ethereum_types::u256::U256::from_bytes_be(&buf).unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::app::storage::redis_storage::test_helper::{find_free_port, run_redis_docker, stop_redis_docker};
+
+    use super::*;
+    use ethers::types::{Address, U256};
+
+    use intmax2_client_sdk::external_api::contract::error::BlockchainError;
+
+    struct MockBalanceProvider {
+        value: U256,
+    }
+    
+    #[async_trait::async_trait]
+    impl EthBalanceProvider for MockBalanceProvider {
+        async fn get_eth_balance(&self, _rpc_url: &str, _address: Address) -> Result<U256, BlockchainError> {
+            Ok(self.value)
+        }
+    }
+    
+    #[tokio::test]
+    async fn test_get_fee_info() {
+        // Initialize our own EnvVar
+        let env = EnvVar {
+            port: 9004,
+            block_builder_url: "http://localhost:9004".to_string(),
+            redis_url: None,
+            cluster_id: Some("1".to_string()),
+            l2_rpc_url: "http://localhost:8545".to_string(),
+            l2_chain_id: 1337,
+            rollup_contract_address: Address::zero(),
+            block_builder_registry_contract_address: Address::zero(),
+            store_vault_server_base_url: "http://localhost:9000".to_string(),
+            use_s3: Some(false),
+            validity_prover_base_url: "http://localhost:9100".to_string(),
+            block_builder_private_key: "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d".parse().unwrap(),   // anvil key
+            eth_allowance_for_block: "0.3".to_string(),
+            tx_timeout: 80,
+            accepting_tx_interval: 40,
+            proposing_block_interval: 10,
+            deposit_check_interval: Some(20),
+            initial_heart_beat_delay: 600,
+            gas_limit_for_block_post: Some(40000),
+            heart_beat_interval: 86400,
+            beneficiary_pubkey: None,
+            registration_fee: Some("0:100,1:2000".to_string()),
+            non_registration_fee: Some("0:100,1:2000".to_string()),
+            registration_collateral_fee: None,
+            non_registration_collateral_fee: None,
+        };
+
+        let block_builder = BlockBuilder::new(&env, Arc::new(MockBalanceProvider{value: U256::from(42u64)})).await.unwrap();
+        let info = block_builder.get_fee_info();
+
+        assert_eq!(info.block_builder_address, block_builder.config.block_builder_address);
+        assert_eq!(info.beneficiary, block_builder.config.beneficiary_pubkey);
+        assert_eq!(info.registration_fee, convert_fee_vec(&block_builder.config.registration_fee));
+        assert_eq!(info.non_registration_fee, convert_fee_vec(&block_builder.config.non_registration_fee));
+    }
+
+    #[tokio::test]
+    async fn test_blockchain_health_check_not_enough_balance() {
+        // Initialize our own EnvVar
+        let env = EnvVar {
+            port: 9004,
+            block_builder_url: "http://localhost:9004".to_string(),
+            redis_url: None,
+            cluster_id: Some("1".to_string()),
+            l2_rpc_url: "http://localhost:8545".to_string(),
+            l2_chain_id: 1337,
+            rollup_contract_address: Address::zero(),
+            block_builder_registry_contract_address: Address::zero(),
+            store_vault_server_base_url: "http://localhost:9000".to_string(),
+            use_s3: Some(false),
+            validity_prover_base_url: "http://localhost:9100".to_string(),
+            block_builder_private_key: "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d".parse().unwrap(),   // anvil key
+            eth_allowance_for_block: "0.001".to_string(),  // this value is important in this test
+            tx_timeout: 80,
+            accepting_tx_interval: 40,
+            proposing_block_interval: 10,
+            deposit_check_interval: Some(20),
+            initial_heart_beat_delay: 600,
+            gas_limit_for_block_post: Some(40000),
+            heart_beat_interval: 86400,
+            beneficiary_pubkey: None,
+            registration_fee: Some("0:100,1:2000".to_string()),
+            non_registration_fee: Some("0:100,1:2000".to_string()),
+            registration_collateral_fee: None,
+            non_registration_collateral_fee: None,
+        };
+
+        let block_builder = BlockBuilder::new(&env, Arc::new(MockBalanceProvider{value: U256::from(42u64)})).await.unwrap();
+        let result = block_builder.blockchain_health_check().await;
+
+        assert!(matches!(result, Err(BlockBuilderError::BlockChainHealthError(_))));
+    }
+
+    #[tokio::test]
+    async fn test_blockchain_health_check_ok() {
+        // Initialize our own EnvVar
+        let env = EnvVar {
+            port: 9004,
+            block_builder_url: "http://localhost:9004".to_string(),
+            redis_url: None,
+            cluster_id: Some("1".to_string()),
+            l2_rpc_url: "http://localhost:8545".to_string(),
+            l2_chain_id: 1337,
+            rollup_contract_address: Address::zero(),
+            block_builder_registry_contract_address: Address::zero(),
+            store_vault_server_base_url: "http://localhost:9000".to_string(),
+            use_s3: Some(false),
+            validity_prover_base_url: "http://localhost:9100".to_string(),
+            block_builder_private_key: "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d".parse().unwrap(),   // anvil key
+            eth_allowance_for_block: "1000000000".to_string(),  // this value is important in this test
+            tx_timeout: 80,
+            accepting_tx_interval: 40,
+            proposing_block_interval: 10,
+            deposit_check_interval: Some(20),
+            initial_heart_beat_delay: 600,
+            gas_limit_for_block_post: Some(40000),
+            heart_beat_interval: 86400,
+            beneficiary_pubkey: None,
+            registration_fee: Some("0:100,1:2000".to_string()),
+            non_registration_fee: Some("0:100,1:2000".to_string()),
+            registration_collateral_fee: None,
+            non_registration_collateral_fee: None,
+        };
+
+        let block_builder = BlockBuilder::new(&env, Arc::new(MockBalanceProvider{value: U256::from(42u64)})).await.unwrap();
+        let result = block_builder.blockchain_health_check().await;
+
+        assert!(matches!(result, Err(BlockBuilderError::BlockChainHealthError(_))));
+    }
+
+    #[tokio::test]
+    async fn test_creating_with_redis() {
+        let port = find_free_port();
+        let cont_name = "block-builder-test-creating-with-redis";
+        
+        // Initialize our own EnvVar
+        let env = EnvVar {
+            port: 9004,
+            block_builder_url: "http://localhost:9004".to_string(),
+            redis_url: Some(format!("redis://localhost:{}", port).to_string()),
+            cluster_id: Some("1".to_string()),
+            l2_rpc_url: "http://localhost:8545".to_string(),
+            l2_chain_id: 1337,
+            rollup_contract_address: Address::zero(),
+            block_builder_registry_contract_address: Address::zero(),
+            store_vault_server_base_url: "http://localhost:9000".to_string(),
+            use_s3: Some(false),
+            validity_prover_base_url: "http://localhost:9100".to_string(),
+            block_builder_private_key: "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d".parse().unwrap(),   // anvil key
+            eth_allowance_for_block: "0.3".to_string(),
+            tx_timeout: 80,
+            accepting_tx_interval: 40,
+            proposing_block_interval: 10,
+            deposit_check_interval: Some(20),
+            initial_heart_beat_delay: 600,
+            gas_limit_for_block_post: Some(40000),
+            heart_beat_interval: 86400,
+            beneficiary_pubkey: None,
+            registration_fee: Some("0:100,1:2000".to_string()),
+            non_registration_fee: Some("0:100,1:2000".to_string()),
+            registration_collateral_fee: None,
+            non_registration_collateral_fee: None,
+        };
+
+        // Run docker image
+        stop_redis_docker(cont_name);
+        let output = run_redis_docker(port, cont_name);
+        assert!(output.status.success(), "Couldn't start {}: {}", cont_name, String::from_utf8_lossy(&output.stderr));
+
+        let _ = BlockBuilder::new(&env, Arc::new(MockBalanceProvider{value: U256::from(42u64)})).await.unwrap();
+
+        // Stop docker image
+        let output = stop_redis_docker(cont_name);
+        assert!(output.status.success(), "Couldn't stop {}: {}", cont_name, String::from_utf8_lossy(&output.stderr));
+    }
 }

--- a/block-builder/src/app/fee.rs
+++ b/block-builder/src/app/fee.rs
@@ -393,22 +393,22 @@ pub fn convert_fee_vec(fee: &Option<HashMap<u32, U256>>) -> Option<Vec<Fee>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
+    use intmax2_zkp::ethereum_types::u256::U256;
     use num_bigint::BigUint;
     use num_traits::One;
-    use intmax2_zkp::ethereum_types::u256::U256;
+    use std::collections::HashMap;
 
     #[test]
     fn test_fee_amount_zero() {
         let fee_str = "0:0";
         let result = parse_fee_str(fee_str).unwrap();
-    
+
         let mut expected = HashMap::new();
         expected.insert(0, U256::default());
-    
+
         assert_eq!(result, expected);
     }
-    
+
     #[test]
     fn test_few_fees() {
         let fee_str = "0:100,1:200";
@@ -462,8 +462,7 @@ mod tests {
         let result = parse_fee_str(fee_str);
 
         assert!(result.is_err());
-        assert!(format!("{}", result.err().unwrap())
-            .contains("Failed to parse token index"));
+        assert!(format!("{}", result.err().unwrap()).contains("Failed to parse token index"));
     }
 
     #[test]
@@ -472,8 +471,7 @@ mod tests {
         let result = parse_fee_str(fee_str);
 
         assert!(result.is_err());
-        assert!(format!("{}", result.err().unwrap())
-            .contains("Failed to parse fee amount"));
+        assert!(format!("{}", result.err().unwrap()).contains("Failed to parse fee amount"));
     }
 
     #[test]
@@ -484,7 +482,11 @@ mod tests {
         let mut expected = HashMap::new();
         expected.insert(
             1u32,
-            U256::try_from(BigUint::parse_bytes("1000000000000000000000000000000000000".as_bytes(), 10).unwrap()).unwrap()
+            U256::try_from(
+                BigUint::parse_bytes("1000000000000000000000000000000000000".as_bytes(), 10)
+                    .unwrap(),
+            )
+            .unwrap(),
         );
 
         assert_eq!(result, expected);
@@ -509,15 +511,15 @@ mod tests {
         // 2^256 — overflow for U256
         let overflow = BigUint::one() << 256;
         let fee_str = format!("0:{}", overflow);
-    
+
         let result = parse_fee_str(&fee_str);
-    
+
         assert!(matches!(
             result,
             Err(FeeError::ParseError(msg)) if msg.contains("Failed to convert fee amount")
         ));
     }
-    
+
     #[test]
     fn test_negative_fee_amount() {
         let fee_str = "0:-100";
@@ -529,7 +531,6 @@ mod tests {
         ));
     }
 
-    
     #[test]
     fn test_maximum_token_index() {
         let fee_str = format!("{}:42", u32::MAX);

--- a/block-builder/src/app/fee.rs
+++ b/block-builder/src/app/fee.rs
@@ -389,3 +389,157 @@ pub fn convert_fee_vec(fee: &Option<HashMap<u32, U256>>) -> Option<Vec<Fee>> {
             .collect()
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use num_bigint::BigUint;
+    use num_traits::One;
+    use intmax2_zkp::ethereum_types::u256::U256;
+
+    #[test]
+    fn test_fee_amount_zero() {
+        let fee_str = "0:0";
+        let result = parse_fee_str(fee_str).unwrap();
+    
+        let mut expected = HashMap::new();
+        expected.insert(0, U256::default());
+    
+        assert_eq!(result, expected);
+    }
+    
+    #[test]
+    fn test_few_fees() {
+        let fee_str = "0:100,1:200";
+        let result = parse_fee_str(fee_str).unwrap();
+
+        let mut expected = HashMap::new();
+        expected.insert(0, U256::try_from(BigUint::from(100u64)).unwrap());
+        expected.insert(1, U256::try_from(BigUint::from(200u64)).unwrap());
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_parse_single_fee() {
+        let fee_str = "42:123456789";
+        let result = parse_fee_str(fee_str).unwrap();
+
+        let mut expected = HashMap::new();
+        expected.insert(42, U256::try_from(BigUint::from(123456789u64)).unwrap());
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_parse_empty_string() {
+        let fee_str = "";
+        let result = parse_fee_str(fee_str);
+
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parse error: Invalid fee format: should be token_index:fee_amount"
+        );
+    }
+
+    #[test]
+    fn test_invalid_format_missing_colon() {
+        let fee_str = "0-100,1:200";
+        let result = parse_fee_str(fee_str);
+
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parse error: Invalid fee format: should be token_index:fee_amount"
+        );
+    }
+
+    #[test]
+    fn test_hex_token_index() {
+        let fee_str = "abc:100";
+        let result = parse_fee_str(fee_str);
+
+        assert!(result.is_err());
+        assert!(format!("{}", result.err().unwrap())
+            .contains("Failed to parse token index"));
+    }
+
+    #[test]
+    fn test_hex_fee_amount() {
+        let fee_str = "0:abc";
+        let result = parse_fee_str(fee_str);
+
+        assert!(result.is_err());
+        assert!(format!("{}", result.err().unwrap())
+            .contains("Failed to parse fee amount"));
+    }
+
+    #[test]
+    fn test_big_fee_amount() {
+        let fee_str = "1:1000000000000000000000000000000000000";
+        let result = parse_fee_str(fee_str).unwrap();
+
+        let mut expected = HashMap::new();
+        expected.insert(
+            1u32,
+            U256::try_from(BigUint::parse_bytes("1000000000000000000000000000000000000".as_bytes(), 10).unwrap()).unwrap()
+        );
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_maximum_u256_fee() {
+        // max = 2^256 - 1
+        let max = (BigUint::one() << 256) - BigUint::one();
+        let fee_str = format!("1:{}", max);
+        let result = parse_fee_str(&fee_str).unwrap();
+
+        let mut expected = HashMap::new();
+        let u256 = U256::try_from(max).unwrap();
+        expected.insert(1, u256);
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_fee_amount_overflow_u256() {
+        // 2^256 — overflow for U256
+        let overflow = BigUint::one() << 256;
+        let fee_str = format!("0:{}", overflow);
+    
+        let result = parse_fee_str(&fee_str);
+    
+        assert!(matches!(
+            result,
+            Err(FeeError::ParseError(msg)) if msg.contains("Failed to convert fee amount")
+        ));
+    }
+    
+    #[test]
+    fn test_negative_fee_amount() {
+        let fee_str = "0:-100";
+        let result = parse_fee_str(fee_str);
+
+        assert!(matches!(
+            result,
+            Err(FeeError::ParseError(msg)) if msg.contains("Failed to parse fee amount")
+        ));
+    }
+
+    
+    #[test]
+    fn test_maximum_token_index() {
+        let fee_str = format!("{}:42", u32::MAX);
+        let result = parse_fee_str(&fee_str).unwrap();
+
+        let mut expected = HashMap::new();
+        let big = BigUint::from(42u32);
+        let u256 = U256::try_from(big).unwrap();
+        expected.insert(u32::MAX, u256);
+
+        assert_eq!(result, expected);
+    }
+}

--- a/block-builder/src/app/storage/memory_storage.rs
+++ b/block-builder/src/app/storage/memory_storage.rs
@@ -337,3 +337,60 @@ impl Storage for InMemoryStorage {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use intmax2_zkp::ethereum_types::{address::Address, u256::U256};
+
+    fn dummy_config() -> StorageConfig {
+        StorageConfig {
+            use_fee: false,
+            use_collateral: false,
+            block_builder_address: Address::default(),
+            fee_beneficiary: U256::default(),
+            tx_timeout: 60,
+            accepting_tx_interval: 10,
+            proposing_block_interval: 10,
+            deposit_check_interval: Some(5),
+            block_builder_id: "builder1".to_string(),
+            redis_url: None,
+            cluster_id: None,
+        }
+    }
+
+    fn dummy_tx_request(request_id: &str) -> TxRequest {
+        TxRequest {
+            request_id: request_id.to_string(),
+            pubkey: U256::from(1),
+            account_id: None,
+            tx: Default::default(), // assuming Tx: Default
+            fee_proof: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_add_tx_registration() {
+        let storage = InMemoryStorage::new(&dummy_config()).await;
+        let tx = dummy_tx_request("reg-1");
+
+        storage.add_tx(true, tx.clone()).await.unwrap();
+
+        let queue = storage.registration_tx_requests.read().await;
+        assert_eq!(queue.len(), 1);
+        assert_eq!(queue.front().unwrap().request_id, tx.request_id);
+    }
+
+    #[tokio::test]
+    async fn test_add_tx_non_registration() {
+        let storage = InMemoryStorage::new(&dummy_config()).await;
+        let tx = dummy_tx_request("nonreg-1");
+
+        storage.add_tx(false, tx.clone()).await.unwrap();
+
+        let queue = storage.non_registration_tx_requests.read().await;
+        assert_eq!(queue.len(), 1);
+        assert_eq!(queue.front().unwrap().request_id, tx.request_id);
+    }
+
+}

--- a/block-builder/src/app/storage/memory_storage.rs
+++ b/block-builder/src/app/storage/memory_storage.rs
@@ -392,5 +392,4 @@ mod tests {
         assert_eq!(queue.len(), 1);
         assert_eq!(queue.front().unwrap().request_id, tx.request_id);
     }
-
 }

--- a/block-builder/src/app/storage/redis_storage.rs
+++ b/block-builder/src/app/storage/redis_storage.rs
@@ -997,3 +997,224 @@ impl Storage for RedisStorage {
         result
     }
 }
+
+#[cfg(test)]
+pub mod test_helper {
+    use std::panic;
+    // For redis
+    use std::{net::TcpListener, process::{Command, Output, Stdio}};
+
+    pub fn run_redis_docker(port: u16, container_name: &str) -> Output{
+        let port_arg = format!("{}:6379", port);
+    
+        let output = Command::new("docker")
+            .args([
+                "run",
+                "-d",
+                "--rm",
+                "--name", container_name,
+                "-p", &port_arg,
+                "redis:latest",
+            ])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .expect("Error during Redis container startup");
+    
+        output
+    }
+
+    pub fn stop_redis_docker(container_name: &str) -> Output {
+        let output = Command::new("docker")
+            .args(["stop", container_name])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .expect("Error during Redis container stopping");
+        
+        output
+    }
+
+    pub fn find_free_port() -> u16 {
+        TcpListener::bind("127.0.0.1:0")
+            .expect("Failed to bind to address")
+            .local_addr()
+            .unwrap()
+            .port()
+    }
+
+    pub fn assert_and_stop<F: FnOnce() + panic::UnwindSafe>(cont_name: &str, f: F) {
+        let res = panic::catch_unwind(f);
+
+        if let Err(panic_info) = res {
+            stop_redis_docker(cont_name);
+            panic::resume_unwind(panic_info);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::panic::AssertUnwindSafe;
+
+    use super::*;
+    use intmax2_client_sdk::client::error::ClientError;
+    use intmax2_zkp::ethereum_types::{address::Address, u256::U256, u32limb_trait::U32LimbTrait};
+    use uuid::Uuid;
+
+    use test_helper::{run_redis_docker, stop_redis_docker, find_free_port, assert_and_stop};
+
+    async fn setup_test_storage(instance_id: &str, redis_port: &str) -> RedisStorage {
+        let config = StorageConfig {
+            use_fee: true,
+            use_collateral: true,
+            block_builder_address: Address::zero(),
+            fee_beneficiary: U256::default(),
+            tx_timeout: 80,
+            accepting_tx_interval: 40,
+            proposing_block_interval: 10,
+            deposit_check_interval: Some(20),
+            redis_url: Some(redis_port.to_string()),
+            cluster_id: Some(instance_id.to_string()),
+            block_builder_id: Uuid::new_v4().to_string(),
+        };
+
+        let storage = RedisStorage::new(&config).await;
+
+        storage
+    }
+
+    #[tokio::test]
+    async fn test_acquire_release_lock() {
+        let port: u16 = 6381;
+        let cont_name = "redis-test-acquire-release";
+
+        // Run docker image
+        stop_redis_docker(cont_name);
+        let output = run_redis_docker(port, cont_name);
+        assert!(output.status.success(), "Couldn't start {}: {}", cont_name, String::from_utf8_lossy(&output.stderr));
+
+        // Create RedisStorage and test locks
+        let redis1 = setup_test_storage("redis-test", "redis://localhost:6381").await;
+        let redis2 = setup_test_storage("redis-test", "redis://localhost:6381").await;
+
+        let acquired1 = redis1.acquire_lock("test_lock").await.unwrap();
+        if !acquired1 {
+            stop_redis_docker(cont_name);
+            assert!(acquired1, "Couldn't acquire lock for redis1");
+        }
+
+        let acquired2 = redis2.acquire_lock("test_lock").await.unwrap();
+        if acquired2 {
+            stop_redis_docker(cont_name);
+            assert!(!acquired2, "Could acquire lock for redis2");
+        }
+
+        redis1.release_lock("test_lock").await.unwrap();
+
+        let acquired2_after = redis2.acquire_lock("test_lock").await.unwrap();
+        if !acquired2_after {
+            stop_redis_docker(cont_name);
+            assert!(acquired2_after, "Couldn't acquire lock for redis-test-2");
+        }
+
+        // Stop docker image
+        let output = stop_redis_docker(cont_name);
+        assert!(output.status.success(), "Couldn't stop {}: {}", cont_name, String::from_utf8_lossy(&output.stderr));
+    }
+
+    #[tokio::test]
+    async fn test_empty_process_requests() {
+        let port = find_free_port();
+        let cont_name = "redis-test-process-requests";
+        
+        // Run docker image
+        stop_redis_docker(cont_name);
+        let output = run_redis_docker(port, cont_name);
+        assert!(output.status.success(), "Couldn't start {}: {}", cont_name, String::from_utf8_lossy(&output.stderr));
+
+        // Create redis storage
+        let redis_storage = setup_test_storage("redis-test", &format!("redis://localhost:{}", port)).await;
+        let res = redis_storage.process_requests(true).await;
+        if !res.is_ok() {
+            stop_redis_docker(cont_name);
+            assert!(res.is_ok());
+        }
+
+        // Stop docker image
+        let output = stop_redis_docker(cont_name);
+        assert!(output.status.success(), "Couldn't stop {}: {}", cont_name, String::from_utf8_lossy(&output.stderr));
+    }
+    
+    #[tokio::test]
+    async fn test_non_empty_process_requests() {
+        let port = find_free_port();
+        let cont_name = "redis-test-non-empty-process-requests";
+        
+        // Run docker image
+        stop_redis_docker(cont_name);
+        let output = run_redis_docker(port, cont_name);
+        assert!(output.status.success(), "Couldn't start {}: {}", cont_name, String::from_utf8_lossy(&output.stderr));
+
+        // Create redis storage
+        let redis_storage = setup_test_storage("redis-test", &format!("redis://localhost:{}", port)).await;
+
+        let res = redis_storage.add_tx(true, TxRequest::default()).await;
+        assert_and_stop(cont_name, AssertUnwindSafe(|| assert!(res.is_ok())));
+
+        let res = redis_storage.process_requests(true).await;
+        assert_and_stop(cont_name, AssertUnwindSafe(|| assert!(res.is_ok())));
+
+        let res = redis_storage.query_proposal(Uuid::default().to_string().as_str()).await;
+        assert_and_stop(cont_name, AssertUnwindSafe(|| assert!(res.is_ok())));
+
+        let block_proposal = res.unwrap().unwrap();
+        assert_and_stop(cont_name, || assert_eq!(block_proposal.block_sign_payload.is_registration_block, true));
+        assert_and_stop(cont_name, || assert_eq!(block_proposal.pubkeys.len(), NUM_SENDERS_IN_BLOCK));
+
+        let res = block_proposal.verify(TxRequest::default().tx)
+            .map_err(|e| ClientError::InvalidBlockProposal(format!("{}", e)));
+        assert_and_stop(cont_name, AssertUnwindSafe(|| assert!(res.is_ok())));
+
+        // Stop docker image
+        let output = stop_redis_docker(cont_name);
+        assert!(output.status.success(), "Couldn't stop {}: {}", cont_name, String::from_utf8_lossy(&output.stderr));
+    }
+
+    #[tokio::test]
+    async fn test_enqueue_dequeue_empty_block_post() {
+        let port = find_free_port();
+        let cont_name = "redis-test-enqueue-dequeue-empty-block-post";
+        
+        // Run docker image
+        stop_redis_docker(cont_name);
+        let output = run_redis_docker(port, cont_name);
+        assert!(output.status.success(), "Couldn't start {}: {}", cont_name, String::from_utf8_lossy(&output.stderr));
+
+        // Create redis storage
+        let redis_storage = setup_test_storage("redis-test", &format!("redis://localhost:{}", port)).await;
+
+        // Test enqueue and dequeue block post task
+        let res = redis_storage.enqueue_empty_block().await;
+        assert_and_stop(cont_name, AssertUnwindSafe(|| assert!(res.is_ok())));
+
+        let res = redis_storage.dequeue_block_post_task().await;
+        assert_and_stop(cont_name, AssertUnwindSafe(|| assert!(res.is_ok())));
+
+        let block_post_task = res.unwrap().unwrap();
+
+        assert_and_stop(cont_name, || assert_eq!(block_post_task.force_post, true));
+
+        assert_and_stop(cont_name, || assert_eq!(block_post_task.block_sign_payload.is_registration_block, false));
+        assert_and_stop(cont_name, || assert_eq!(block_post_task.block_sign_payload.block_builder_address, Address::default()));
+        assert_and_stop(cont_name, || assert_eq!(block_post_task.block_sign_payload.block_builder_nonce, u32::default()));
+        
+        assert_and_stop(cont_name, || assert_eq!(block_post_task.pubkeys.len(), NUM_SENDERS_IN_BLOCK));
+        
+        assert_and_stop(cont_name, || assert!(block_post_task.account_ids.is_some()));
+
+        // Stop docker image
+        let output = stop_redis_docker(cont_name);
+        assert!(output.status.success(), "Couldn't stop {}: {}", cont_name, String::from_utf8_lossy(&output.stderr));
+    }
+}

--- a/block-builder/src/app/types.rs
+++ b/block-builder/src/app/types.rs
@@ -65,11 +65,13 @@ impl ProposalMemo {
         tx_requests: &[TxRequest],
         tx_timeout: u64,
     ) -> Self {
-        assert!(tx_requests.len() <= NUM_SENDERS_IN_BLOCK,
+        assert!(
+            tx_requests.len() <= NUM_SENDERS_IN_BLOCK,
             "tx_requests.len() = {}, which exceeds NUM_SENDERS_IN_BLOCK = {}",
             tx_requests.len(),
-            NUM_SENDERS_IN_BLOCK);
-        
+            NUM_SENDERS_IN_BLOCK
+        );
+
         let expiry = tx_timeout + chrono::Utc::now().timestamp() as u64;
         let mut sorted_and_padded_txs = tx_requests.to_vec();
         sorted_and_padded_txs.sort_by(|a, b| b.pubkey.cmp(&a.pubkey));
@@ -166,10 +168,10 @@ impl ProposalMemo {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use intmax2_zkp::constants::NUM_SENDERS_IN_BLOCK;
-    use intmax2_zkp::ethereum_types::u256::U256;
-    use intmax2_zkp::common::tx::Tx;
-    
+    use intmax2_zkp::{
+        common::tx::Tx, constants::NUM_SENDERS_IN_BLOCK, ethereum_types::u256::U256,
+    };
+
     use num_bigint::BigUint;
 
     #[test]
@@ -182,13 +184,7 @@ mod tests {
             ..Default::default()
         }];
 
-        let memo = ProposalMemo::from_tx_requests(
-            false,
-            Address::default(),
-            0,
-            &tx_requests,
-            1000,
-        );
+        let memo = ProposalMemo::from_tx_requests(false, Address::default(), 0, &tx_requests, 1000);
 
         assert_eq!(memo.tx_requests.len(), 1);
         assert_eq!(memo.pubkeys.len(), NUM_SENDERS_IN_BLOCK);
@@ -199,19 +195,22 @@ mod tests {
     #[test]
     fn test_pubkey_sorting() {
         let tx_requests = vec![
-            TxRequest { pubkey: U256::from(5), ..Default::default() },
-            TxRequest { pubkey: U256::from(10), ..Default::default() },
-            TxRequest { pubkey: U256::from(1), ..Default::default() },
+            TxRequest {
+                pubkey: U256::from(5),
+                ..Default::default()
+            },
+            TxRequest {
+                pubkey: U256::from(10),
+                ..Default::default()
+            },
+            TxRequest {
+                pubkey: U256::from(1),
+                ..Default::default()
+            },
         ];
-    
-        let memo = ProposalMemo::from_tx_requests(
-            false,
-            Address::default(),
-            0,
-            &tx_requests,
-            1000,
-        );
-    
+
+        let memo = ProposalMemo::from_tx_requests(false, Address::default(), 0, &tx_requests, 1000);
+
         let expected = vec![U256::from(10), U256::from(5), U256::from(1)];
         for (i, pk) in expected.iter().enumerate() {
             assert_eq!(memo.pubkeys[i], *pk);
@@ -220,17 +219,12 @@ mod tests {
 
     #[test]
     fn test_padding_to_num_senders() {
-        let tx_requests = vec![
-            TxRequest { pubkey: U256::from(2), ..Default::default() },
-        ];
+        let tx_requests = vec![TxRequest {
+            pubkey: U256::from(2),
+            ..Default::default()
+        }];
 
-        let memo = ProposalMemo::from_tx_requests(
-            false,
-            Address::default(),
-            0,
-            &tx_requests,
-            1000,
-        );
+        let memo = ProposalMemo::from_tx_requests(false, Address::default(), 0, &tx_requests, 1000);
 
         assert_eq!(memo.pubkeys.len(), NUM_SENDERS_IN_BLOCK);
         assert_eq!(memo.pubkeys[0], U256::from(2));
@@ -242,17 +236,17 @@ mod tests {
     #[test]
     fn test_tx_index_proposal() {
         let tx_requests = vec![
-            TxRequest { pubkey: U256::from(3), ..Default::default() },
-            TxRequest { pubkey: U256::from(5), ..Default::default() },
+            TxRequest {
+                pubkey: U256::from(3),
+                ..Default::default()
+            },
+            TxRequest {
+                pubkey: U256::from(5),
+                ..Default::default()
+            },
         ];
 
-        let memo = ProposalMemo::from_tx_requests(
-            false,
-            Address::default(),
-            0,
-            &tx_requests,
-            1000,
-        );
+        let memo = ProposalMemo::from_tx_requests(false, Address::default(), 0, &tx_requests, 1000);
 
         let proposal = &memo.proposals[0];
         assert_eq!(proposal.tx_index, 1);
@@ -261,13 +255,7 @@ mod tests {
     #[test]
     fn test_registration_block_skips_account_ids() {
         let tx_requests = vec![TxRequest::default()];
-        let memo = ProposalMemo::from_tx_requests(
-            true,
-            Address::default(),
-            0,
-            &tx_requests,
-            1000,
-        );
+        let memo = ProposalMemo::from_tx_requests(true, Address::default(), 0, &tx_requests, 1000);
 
         assert_eq!(memo.get_account_ids(), None);
     }
@@ -282,13 +270,7 @@ mod tests {
             ..Default::default()
         }];
 
-        let memo = ProposalMemo::from_tx_requests(
-            false,
-            Address::default(),
-            0,
-            &tx_requests,
-            1000,
-        );
+        let memo = ProposalMemo::from_tx_requests(false, Address::default(), 0, &tx_requests, 1000);
 
         let proposal = memo.get_proposal(pubkey, tx);
         assert!(proposal.is_some());
@@ -297,13 +279,7 @@ mod tests {
 
     #[test]
     fn test_empty_tx_requests() {
-        let memo = ProposalMemo::from_tx_requests(
-            false,
-            Address::default(),
-            0,
-            &[],
-            1000,
-        );
+        let memo = ProposalMemo::from_tx_requests(false, Address::default(), 0, &[], 1000);
 
         assert_eq!(memo.tx_requests.len(), 0);
         assert_eq!(memo.proposals.len(), 0);
@@ -318,17 +294,19 @@ mod tests {
         let tx2 = Tx::default();
 
         let tx_requests = vec![
-            TxRequest { pubkey, tx: tx1, ..Default::default() },
-            TxRequest { pubkey, tx: tx2, ..Default::default() },
+            TxRequest {
+                pubkey,
+                tx: tx1,
+                ..Default::default()
+            },
+            TxRequest {
+                pubkey,
+                tx: tx2,
+                ..Default::default()
+            },
         ];
 
-        let memo = ProposalMemo::from_tx_requests(
-            false,
-            Address::default(),
-            0,
-            &tx_requests,
-            1000,
-        );
+        let memo = ProposalMemo::from_tx_requests(false, Address::default(), 0, &tx_requests, 1000);
 
         assert_eq!(memo.tx_requests.len(), 2);
         assert_eq!(memo.proposals.len(), 2);
@@ -348,13 +326,7 @@ mod tests {
             })
             .collect();
 
-        let memo = ProposalMemo::from_tx_requests(
-            false,
-            Address::default(),
-            0,
-            &tx_requests,
-            1000,
-        );
+        let memo = ProposalMemo::from_tx_requests(false, Address::default(), 0, &tx_requests, 1000);
 
         // Proposals should be only for the original tx_requests
         assert_eq!(memo.proposals.len(), NUM_SENDERS_IN_BLOCK);
@@ -378,12 +350,6 @@ mod tests {
             })
             .collect();
 
-        let _ = ProposalMemo::from_tx_requests(
-            false,
-            Address::default(),
-            0,
-            &tx_requests,
-            1000,
-        );
+        let _ = ProposalMemo::from_tx_requests(false, Address::default(), 0, &tx_requests, 1000);
     }
 }

--- a/block-builder/src/app/types.rs
+++ b/block-builder/src/app/types.rs
@@ -211,7 +211,7 @@ mod tests {
 
         let memo = ProposalMemo::from_tx_requests(false, Address::default(), 0, &tx_requests, 1000);
 
-        let expected = vec![U256::from(10), U256::from(5), U256::from(1)];
+        let expected = [U256::from(10), U256::from(5), U256::from(1)];
         for (i, pk) in expected.iter().enumerate() {
             assert_eq!(memo.pubkeys[i], *pk);
         }

--- a/block-builder/src/app/types.rs
+++ b/block-builder/src/app/types.rs
@@ -50,6 +50,14 @@ pub struct ProposalMemo {
 }
 
 impl ProposalMemo {
+    /// Create proposal memo for the provided tx requests.
+    ///
+    /// # Arguments
+    /// * `is_registration_block` - Bool value if the block should be the registration one
+    /// * `block_builder_address` - Block builder address
+    /// * `block_builder_nonce` - Block builder nonce
+    /// * `tx_requests` - Transaction requests. Its length should be in [0; NUM_SENDERS_IN_BLOCK)
+    /// * `tx_timeout` - Transaction timeout
     pub fn from_tx_requests(
         is_registration_block: bool,
         block_builder_address: Address,
@@ -57,6 +65,11 @@ impl ProposalMemo {
         tx_requests: &[TxRequest],
         tx_timeout: u64,
     ) -> Self {
+        assert!(tx_requests.len() <= NUM_SENDERS_IN_BLOCK,
+            "tx_requests.len() = {}, which exceeds NUM_SENDERS_IN_BLOCK = {}",
+            tx_requests.len(),
+            NUM_SENDERS_IN_BLOCK);
+        
         let expiry = tx_timeout + chrono::Utc::now().timestamp() as u64;
         let mut sorted_and_padded_txs = tx_requests.to_vec();
         sorted_and_padded_txs.sort_by(|a, b| b.pubkey.cmp(&a.pubkey));
@@ -108,7 +121,11 @@ impl ProposalMemo {
         }
     }
 
-    // get the proposal for a given pubkey and tx if it exists
+    /// Get the proposal for a given pubkey and tx if it exists.
+    ///
+    /// # Arguments
+    /// * `pubkey` - Public key to be compared
+    /// * `tx` - Transaction to be compared
     pub fn get_proposal(&self, pubkey: U256, tx: Tx) -> Option<BlockProposal> {
         let position = self
             .tx_requests
@@ -117,7 +134,10 @@ impl ProposalMemo {
         position.map(|pos| self.proposals[pos].clone())
     }
 
-    // get the account id for a given pubkey
+    /// Get the account id for a given pubkey.
+    ///
+    /// # Arguments
+    /// * `pubkey` - Given public key
     fn get_account_id(&self, pubkey: U256) -> Option<AccountId> {
         if pubkey == U256::dummy_pubkey() {
             return Some(AccountId::dummy());
@@ -128,7 +148,7 @@ impl ProposalMemo {
             .and_then(|r| r.account_id)
     }
 
-    // get the account ids for the tx requests in the memo
+    /// Get the account ids for the tx requests in the memo.
     pub fn get_account_ids(&self) -> Option<AccountIdPacked> {
         if self.block_sign_payload.is_registration_block {
             None
@@ -140,5 +160,230 @@ impl ProposalMemo {
                 .collect();
             Some(AccountIdPacked::pack(&account_ids))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use intmax2_zkp::constants::NUM_SENDERS_IN_BLOCK;
+    use intmax2_zkp::ethereum_types::u256::U256;
+    use intmax2_zkp::common::tx::Tx;
+    
+    use num_bigint::BigUint;
+
+    #[test]
+    fn test_basic_from_tx_requests() {
+        let pubkey = U256::from(1);
+        let tx = Tx::default();
+        let tx_requests = vec![TxRequest {
+            pubkey,
+            tx,
+            ..Default::default()
+        }];
+
+        let memo = ProposalMemo::from_tx_requests(
+            false,
+            Address::default(),
+            0,
+            &tx_requests,
+            1000,
+        );
+
+        assert_eq!(memo.tx_requests.len(), 1);
+        assert_eq!(memo.pubkeys.len(), NUM_SENDERS_IN_BLOCK);
+        assert_eq!(memo.proposals.len(), 1);
+        assert_eq!(memo.pubkeys[0], pubkey);
+    }
+
+    #[test]
+    fn test_pubkey_sorting() {
+        let tx_requests = vec![
+            TxRequest { pubkey: U256::from(5), ..Default::default() },
+            TxRequest { pubkey: U256::from(10), ..Default::default() },
+            TxRequest { pubkey: U256::from(1), ..Default::default() },
+        ];
+    
+        let memo = ProposalMemo::from_tx_requests(
+            false,
+            Address::default(),
+            0,
+            &tx_requests,
+            1000,
+        );
+    
+        let expected = vec![U256::from(10), U256::from(5), U256::from(1)];
+        for (i, pk) in expected.iter().enumerate() {
+            assert_eq!(memo.pubkeys[i], *pk);
+        }
+    }
+
+    #[test]
+    fn test_padding_to_num_senders() {
+        let tx_requests = vec![
+            TxRequest { pubkey: U256::from(2), ..Default::default() },
+        ];
+
+        let memo = ProposalMemo::from_tx_requests(
+            false,
+            Address::default(),
+            0,
+            &tx_requests,
+            1000,
+        );
+
+        assert_eq!(memo.pubkeys.len(), NUM_SENDERS_IN_BLOCK);
+        assert_eq!(memo.pubkeys[0], U256::from(2));
+        for pk in memo.pubkeys.iter().skip(1) {
+            assert_eq!(*pk, U256::dummy_pubkey());
+        }
+    }
+
+    #[test]
+    fn test_tx_index_proposal() {
+        let tx_requests = vec![
+            TxRequest { pubkey: U256::from(3), ..Default::default() },
+            TxRequest { pubkey: U256::from(5), ..Default::default() },
+        ];
+
+        let memo = ProposalMemo::from_tx_requests(
+            false,
+            Address::default(),
+            0,
+            &tx_requests,
+            1000,
+        );
+
+        let proposal = &memo.proposals[0];
+        assert_eq!(proposal.tx_index, 1);
+    }
+
+    #[test]
+    fn test_registration_block_skips_account_ids() {
+        let tx_requests = vec![TxRequest::default()];
+        let memo = ProposalMemo::from_tx_requests(
+            true,
+            Address::default(),
+            0,
+            &tx_requests,
+            1000,
+        );
+
+        assert_eq!(memo.get_account_ids(), None);
+    }
+
+    #[test]
+    fn test_get_proposal() {
+        let pubkey = U256::from(42);
+        let tx = Tx::default();
+        let tx_requests = vec![TxRequest {
+            pubkey,
+            tx,
+            ..Default::default()
+        }];
+
+        let memo = ProposalMemo::from_tx_requests(
+            false,
+            Address::default(),
+            0,
+            &tx_requests,
+            1000,
+        );
+
+        let proposal = memo.get_proposal(pubkey, tx);
+        assert!(proposal.is_some());
+        assert_eq!(proposal.unwrap().pubkeys[0], pubkey);
+    }
+
+    #[test]
+    fn test_empty_tx_requests() {
+        let memo = ProposalMemo::from_tx_requests(
+            false,
+            Address::default(),
+            0,
+            &[],
+            1000,
+        );
+
+        assert_eq!(memo.tx_requests.len(), 0);
+        assert_eq!(memo.proposals.len(), 0);
+        assert_eq!(memo.pubkeys.len(), NUM_SENDERS_IN_BLOCK);
+        assert!(memo.pubkeys.iter().all(|p| *p == U256::dummy_pubkey()));
+    }
+
+    #[test]
+    fn test_duplicate_pubkeys() {
+        let pubkey = U256::from(123);
+        let tx1 = Tx::default();
+        let tx2 = Tx::default();
+
+        let tx_requests = vec![
+            TxRequest { pubkey, tx: tx1, ..Default::default() },
+            TxRequest { pubkey, tx: tx2, ..Default::default() },
+        ];
+
+        let memo = ProposalMemo::from_tx_requests(
+            false,
+            Address::default(),
+            0,
+            &tx_requests,
+            1000,
+        );
+
+        assert_eq!(memo.tx_requests.len(), 2);
+        assert_eq!(memo.proposals.len(), 2);
+
+        let idx_0 = memo.proposals[0].tx_index;
+        let idx_1 = memo.proposals[1].tx_index;
+
+        assert_eq!(idx_0, idx_1);
+    }
+
+    #[test]
+    fn test_full_tx_requests_in_block() {
+        let tx_requests: Vec<TxRequest> = (0..(NUM_SENDERS_IN_BLOCK))
+            .map(|i| TxRequest {
+                pubkey: U256::try_from(BigUint::from(i)).unwrap(),
+                ..Default::default()
+            })
+            .collect();
+
+        let memo = ProposalMemo::from_tx_requests(
+            false,
+            Address::default(),
+            0,
+            &tx_requests,
+            1000,
+        );
+
+        // Proposals should be only for the original tx_requests
+        assert_eq!(memo.proposals.len(), NUM_SENDERS_IN_BLOCK);
+
+        // Pubkeys should be limited by NUM_SENDERS_IN_BLOCK
+        assert_eq!(memo.pubkeys.len(), NUM_SENDERS_IN_BLOCK);
+
+        // Check that no one pubkey is above the allowed value
+        for pk in memo.pubkeys.iter() {
+            assert!(pk <= &U256::try_from(BigUint::from(NUM_SENDERS_IN_BLOCK)).unwrap());
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "tx_requests.len()")]
+    fn test_exceeding_tx_requests_in_block() {
+        let tx_requests: Vec<TxRequest> = (0..(NUM_SENDERS_IN_BLOCK + 1))
+            .map(|i| TxRequest {
+                pubkey: U256::try_from(BigUint::from(i)).unwrap(),
+                ..Default::default()
+            })
+            .collect();
+
+        let _ = ProposalMemo::from_tx_requests(
+            false,
+            Address::default(),
+            0,
+            &tx_requests,
+            1000,
+        );
     }
 }


### PR DESCRIPTION
Added tests and added balance_provider in BlockBuilder for mocking (some tests require running docker service).

Tried to refactor _from_tx_requests_ from ProposalMemo in types.rs. In short, _Sorted_and_padded_txs_ must always be the size of NUM_SENDERS_IN_BLOCK. Otherwise, panic occurs in intmax2-zkp.