### PR TITLE
L1 tx hash for withdrawal and claim

### DIFF
--- a/.sqlx/query-2b28fb656aa5853a3a7683a24f894b35a06e1c90bf9948f28ab9b320d0f8f20d.json
+++ b/.sqlx/query-2b28fb656aa5853a3a7683a24f894b35a06e1c90bf9948f28ab9b320d0f8f20d.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT \n                status as \"status: SqlWithdrawalStatus\",\n                contract_withdrawal\n            FROM withdrawals\n            WHERE recipient = $1\n            ",
+  "query": "\n            SELECT \n                status as \"status: SqlWithdrawalStatus\",\n                contract_withdrawal,\n                l1_tx_hash\n            FROM withdrawals\n            WHERE pubkey = $1\n            ",
   "describe": {
     "columns": [
       {
@@ -25,6 +25,11 @@
         "ordinal": 1,
         "name": "contract_withdrawal",
         "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 2,
+        "name": "l1_tx_hash",
+        "type_info": "Bpchar"
       }
     ],
     "parameters": {
@@ -34,8 +39,9 @@
     },
     "nullable": [
       false,
-      false
+      false,
+      true
     ]
   },
-  "hash": "8be2904b8c3515f538fcadfac8dde2355dd1d53e97cc8584d3d1b7e4fb2223e0"
+  "hash": "2b28fb656aa5853a3a7683a24f894b35a06e1c90bf9948f28ab9b320d0f8f20d"
 }

--- a/.sqlx/query-c3c9b812114c4d838f006b72147a6eee3380551424c8d7b95bcf5160f06283ad.json
+++ b/.sqlx/query-c3c9b812114c4d838f006b72147a6eee3380551424c8d7b95bcf5160f06283ad.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT \n                status as \"status: SqlWithdrawalStatus\",\n                contract_withdrawal\n            FROM withdrawals\n            WHERE pubkey = $1\n            ",
+  "query": "\n            SELECT \n                status as \"status: SqlWithdrawalStatus\",\n                contract_withdrawal,\n                l1_tx_hash\n            FROM withdrawals\n            WHERE recipient = $1\n            ",
   "describe": {
     "columns": [
       {
@@ -25,6 +25,11 @@
         "ordinal": 1,
         "name": "contract_withdrawal",
         "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 2,
+        "name": "l1_tx_hash",
+        "type_info": "Bpchar"
       }
     ],
     "parameters": {
@@ -34,8 +39,9 @@
     },
     "nullable": [
       false,
-      false
+      false,
+      true
     ]
   },
-  "hash": "3a26d9822923052e45d40808367d06ed8b968af0f0bcf2767a7a5ca6df938ab0"
+  "hash": "c3c9b812114c4d838f006b72147a6eee3380551424c8d7b95bcf5160f06283ad"
 }

--- a/.sqlx/query-e8f56279f670e4057330cbe1d6f37d5fb4666606223d300e71a70e66e20947a3.json
+++ b/.sqlx/query-e8f56279f670e4057330cbe1d6f37d5fb4666606223d300e71a70e66e20947a3.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT \n                status as \"status: SqlClaimStatus\",\n                claim\n            FROM claims\n            WHERE pubkey = $1\n            ",
+  "query": "\n            SELECT \n                status as \"status: SqlClaimStatus\",\n                claim,\n                l1_tx_hash\n            FROM claims\n            WHERE pubkey = $1\n            ",
   "describe": {
     "columns": [
       {
@@ -25,6 +25,11 @@
         "ordinal": 1,
         "name": "claim",
         "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 2,
+        "name": "l1_tx_hash",
+        "type_info": "Bpchar"
       }
     ],
     "parameters": {
@@ -34,8 +39,9 @@
     },
     "nullable": [
       false,
-      false
+      false,
+      true
     ]
   },
-  "hash": "944c1b7a770cbe297b25bc2d0fd23a23adab87a08fc512a1067427aa86a99234"
+  "hash": "e8f56279f670e4057330cbe1d6f37d5fb4666606223d300e71a70e66e20947a3"
 }

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Please refer to [the examples of cli ](cli/README.md#examples)
 ## Reset DB
 
 ```bash
-(cd store-vault-server && sqlx database reset -y && sqlx database setup && cd ../validity-prover && sqlx database reset -y && sqlx database setup && cd ../withdrawal-server && sqlx database reset -y && sqlx database setup)
+(cd store-vault-server && sqlx database reset -y && cd ../legacy-store-vault-server && sqlx database reset -y && sqlx database setup && cd ../validity-prover && sqlx database reset -y && sqlx database setup && cd ../withdrawal-server && sqlx database reset -y && sqlx database setup)
 ```
 
 ## When you update the sql queries

--- a/cli/src/cli/get.rs
+++ b/cli/src/cli/get.rs
@@ -1,5 +1,8 @@
 use intmax2_interfaces::data::deposit_data::TokenType;
-use intmax2_zkp::common::{signature_content::key_set::KeySet, trees::asset_tree::AssetLeaf};
+use intmax2_zkp::{
+    common::{signature_content::key_set::KeySet, trees::asset_tree::AssetLeaf},
+    ethereum_types::u32limb_trait::U32LimbTrait,
+};
 
 use crate::cli::{client::get_client, history::format_timestamp};
 
@@ -48,12 +51,16 @@ pub async fn withdrawal_status(key: KeySet) -> Result<(), CliError> {
     println!("Withdrawal status:");
     for (i, withdrawal_info) in withdrawal_info.iter().enumerate() {
         let withdrawal = withdrawal_info.contract_withdrawal.clone();
+        let l1_tx_hash = withdrawal_info
+            .l1_tx_hash
+            .map_or("N/A".to_string(), |h| h.to_hex());
         println!(
-            "#{}: recipient: {}, token_index: {}, amount: {}, status: {}",
+            "#{}: recipient: {}, token_index: {}, amount: {}, l1_tx_hash: {}, status: {}",
             i,
             withdrawal.recipient,
             withdrawal.token_index,
             withdrawal.amount,
+            l1_tx_hash,
             withdrawal_info.status
         );
     }
@@ -84,9 +91,12 @@ pub async fn claim_status(key: KeySet) -> Result<(), CliError> {
     println!("Claim status:");
     for (i, claim_info) in claim_info.iter().enumerate() {
         let claim = claim_info.claim.clone();
+        let l1_tx_hash = claim_info
+            .l1_tx_hash
+            .map_or("N/A".to_string(), |h| h.to_hex());
         println!(
-            "#{}: recipient: {}, amount: {}, status: {}",
-            i, claim.recipient, claim.amount, claim_info.status
+            "#{}: recipient: {}, amount: {}, l1_tx_hash: {}, status: {}",
+            i, claim.recipient, claim.amount, l1_tx_hash, claim_info.status
         );
     }
     Ok(())

--- a/interfaces/src/api/withdrawal_server/interface.rs
+++ b/interfaces/src/api/withdrawal_server/interface.rs
@@ -38,6 +38,7 @@ pub struct ClaimFeeInfo {
 pub struct WithdrawalInfo {
     pub status: WithdrawalStatus,
     pub contract_withdrawal: ContractWithdrawal,
+    pub l1_tx_hash: Option<Bytes32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -45,6 +46,7 @@ pub struct WithdrawalInfo {
 pub struct ClaimInfo {
     pub status: ClaimStatus,
     pub claim: Claim,
+    pub l1_tx_hash: Option<Bytes32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/wasm/src/js_types/common.rs
+++ b/wasm/src/js_types/common.rs
@@ -268,6 +268,7 @@ impl TryFrom<JsMetaData> for MetaData {
 pub struct JsWithdrawalInfo {
     pub status: String,
     pub contract_withdrawal: JsContractWithdrawal,
+    pub l1_tx_hash: Option<String>,
 }
 
 impl From<WithdrawalInfo> for JsWithdrawalInfo {
@@ -275,6 +276,7 @@ impl From<WithdrawalInfo> for JsWithdrawalInfo {
         Self {
             status: withdrawal_info.status.to_string(),
             contract_withdrawal: withdrawal_info.contract_withdrawal.into(),
+            l1_tx_hash: withdrawal_info.l1_tx_hash.map(|hash| hash.to_hex()),
         }
     }
 }
@@ -284,6 +286,7 @@ impl From<WithdrawalInfo> for JsWithdrawalInfo {
 pub struct JsClaimInfo {
     pub status: String,
     pub claim: JsClaim,
+    pub l1_tx_hash: Option<String>,
 }
 
 impl From<ClaimInfo> for JsClaimInfo {
@@ -291,6 +294,7 @@ impl From<ClaimInfo> for JsClaimInfo {
         Self {
             status: claim_info.status.to_string(),
             claim: claim_info.claim.into(),
+            l1_tx_hash: claim_info.l1_tx_hash.map(|hash| hash.to_hex()),
         }
     }
 }

--- a/withdrawal-server/migrations/20250501090900_add_l1_tx_hash.down.sql
+++ b/withdrawal-server/migrations/20250501090900_add_l1_tx_hash.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE withdrawals
+DROP COLUMN IF EXISTS l1_tx_hash;
+
+ALTER TABLE claims
+DROP COLUMN IF EXISTS l1_tx_hash;

--- a/withdrawal-server/migrations/20250501090900_add_l1_tx_hash.up.sql
+++ b/withdrawal-server/migrations/20250501090900_add_l1_tx_hash.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE withdrawals
+ADD COLUMN l1_tx_hash CHAR(66);
+
+ALTER TABLE claims
+ADD COLUMN l1_tx_hash CHAR(66);

--- a/withdrawal-server/src/app/withdrawal_server.rs
+++ b/withdrawal-server/src/app/withdrawal_server.rs
@@ -392,7 +392,8 @@ impl WithdrawalServer {
             r#"
             SELECT 
                 status as "status: SqlWithdrawalStatus",
-                contract_withdrawal
+                contract_withdrawal,
+                l1_tx_hash
             FROM withdrawals
             WHERE pubkey = $1
             "#,
@@ -409,6 +410,7 @@ impl WithdrawalServer {
             withdrawal_infos.push(WithdrawalInfo {
                 status: record.status.into(),
                 contract_withdrawal,
+                l1_tx_hash: record.l1_tx_hash.map(|h| Bytes32::from_hex(&h).unwrap()),
             });
         }
         Ok(withdrawal_infos)
@@ -423,7 +425,8 @@ impl WithdrawalServer {
             r#"
             SELECT 
                 status as "status: SqlClaimStatus",
-                claim
+                claim,
+                l1_tx_hash
             FROM claims
             WHERE pubkey = $1
             "#,
@@ -439,6 +442,7 @@ impl WithdrawalServer {
             claim_infos.push(ClaimInfo {
                 status: record.status.into(),
                 claim,
+                l1_tx_hash: record.l1_tx_hash.map(|h| Bytes32::from_hex(&h).unwrap()),
             });
         }
         Ok(claim_infos)
@@ -453,7 +457,8 @@ impl WithdrawalServer {
             r#"
             SELECT 
                 status as "status: SqlWithdrawalStatus",
-                contract_withdrawal
+                contract_withdrawal,
+                l1_tx_hash
             FROM withdrawals
             WHERE recipient = $1
             "#,
@@ -470,6 +475,7 @@ impl WithdrawalServer {
             withdrawal_infos.push(WithdrawalInfo {
                 status: record.status.into(),
                 contract_withdrawal,
+                l1_tx_hash: record.l1_tx_hash.map(|h| Bytes32::from_hex(&h).unwrap()),
             });
         }
         Ok(withdrawal_infos)


### PR DESCRIPTION
Added l1 tx hash to withdrawal info/claim info to display the corresponding l1 tx hash for withdrawals/claims on the frontend.

- Added l1_tx_hash field to withdrawal info and claim info.
- Migration of the withdrawal server will be required.