### PR TITLE
Fix `sync_withdrawals` & `sync_claims` duplication bug

### DIFF
--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -91,6 +91,10 @@ pub enum Commands {
         #[clap(long, default_value = "false")]
         without_sync: bool,
     },
+    UserData {
+        #[clap(long)]
+        private_key: Bytes32,
+    },
     History {
         #[clap(long)]
         private_key: Bytes32,
@@ -116,6 +120,12 @@ pub enum Commands {
         private_key: Bytes32,
         #[clap(long)]
         eth_private_key: Bytes32,
+    },
+    PaymentMemos {
+        #[clap(long)]
+        private_key: Bytes32,
+        #[clap(long)]
+        name: String,
     },
     ClaimBuilderReward {
         #[clap(long)]

--- a/cli/src/cli/get.rs
+++ b/cli/src/cli/get.rs
@@ -1,3 +1,5 @@
+use colored::Colorize;
+use intmax2_client_sdk::client::misc::payment_memo::get_all_payment_memos;
 use intmax2_interfaces::data::deposit_data::TokenType;
 use intmax2_zkp::{
     common::{signature_content::key_set::KeySet, trees::asset_tree::AssetLeaf},
@@ -105,5 +107,54 @@ pub async fn claim_status(key: KeySet) -> Result<(), CliError> {
 pub async fn check_validity_prover() -> Result<(), CliError> {
     let client = get_client()?;
     client.check_validity_prover().await?;
+    Ok(())
+}
+
+pub async fn get_payment_memos(key: KeySet, name: &str) -> Result<(), CliError> {
+    let client = get_client()?;
+    let payment_memos =
+        get_all_payment_memos(client.store_vault_server.as_ref(), key, name).await?;
+    println!("Payment memos:");
+    for (i, memo) in payment_memos.iter().enumerate() {
+        println!(
+            "#{}: digest: {}, timestamp: {}, memo: {}",
+            i,
+            memo.meta.digest.to_hex(),
+            format_timestamp(memo.meta.timestamp),
+            memo.memo
+        );
+    }
+    Ok(())
+}
+
+pub async fn get_user_data(key: KeySet) -> Result<(), CliError> {
+    let client = get_client()?;
+    let user_data = client.get_user_data(key).await?;
+    println!(
+        "{}: {:?}\n",
+        "Nullifiers".bright_magenta(),
+        user_data.full_private_state.nullifier_tree.nullifiers()
+    );
+    println!(
+        "{}: {:?}\n",
+        "Deposit Status".bright_blue(),
+        user_data.deposit_status
+    );
+    println!(
+        "{}: {:?}\n",
+        "Transfer Status".bright_green(),
+        user_data.transfer_status
+    );
+    println!("{}: {:?}\n", "Tx Status".bright_cyan(), user_data.tx_status);
+    println!(
+        "{}: {:?}\n",
+        "Withdrawal Status".bright_yellow(),
+        user_data.withdrawal_status
+    );
+    println!(
+        "{}: {:?}\n",
+        "Claim Status".bright_red(),
+        user_data.claim_status
+    );
     Ok(())
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -7,7 +7,10 @@ use intmax2_cli::{
         claim::{claim_builder_reward, claim_withdrawals},
         deposit::deposit,
         error::CliError,
-        get::{balance, check_validity_prover, claim_status, mining_list, withdrawal_status},
+        get::{
+            balance, check_validity_prover, claim_status, get_payment_memos, get_user_data,
+            mining_list, withdrawal_status,
+        },
         history::history,
         send::send_transfers,
         sync::{resync, sync_claims, sync_withdrawals},
@@ -178,6 +181,10 @@ async fn main_process(command: Commands) -> Result<(), CliError> {
             let key = privkey_to_keyset(private_key);
             balance(key, !without_sync).await?;
         }
+        Commands::UserData { private_key } => {
+            let key = privkey_to_keyset(private_key);
+            get_user_data(key).await?;
+        }
         Commands::History {
             private_key,
             order,
@@ -198,6 +205,10 @@ async fn main_process(command: Commands) -> Result<(), CliError> {
         Commands::ClaimStatus { private_key } => {
             let key = privkey_to_keyset(private_key);
             claim_status(key).await?;
+        }
+        Commands::PaymentMemos { private_key, name } => {
+            let key = privkey_to_keyset(private_key);
+            get_payment_memos(key, &name).await?;
         }
         Commands::ClaimWithdrawals {
             private_key,

--- a/client-sdk/src/client/sync/sync_claims.rs
+++ b/client-sdk/src/client/sync/sync_claims.rs
@@ -36,6 +36,7 @@ impl Client {
         let minings = determine_claims(
             self.store_vault_server.as_ref(),
             self.validity_prover.as_ref(),
+            self.withdrawal_server.as_ref(),
             &self.rollup_contract,
             &self.liquidity_contract,
             self.config.is_faster_mining,

--- a/client-sdk/src/client/sync/sync_withdrawals.rs
+++ b/client-sdk/src/client/sync/sync_withdrawals.rs
@@ -40,6 +40,7 @@ impl Client {
         let (withdrawals, pending) = determine_withdrawals(
             self.store_vault_server.as_ref(),
             self.validity_prover.as_ref(),
+            self.withdrawal_server.as_ref(),
             &self.rollup_contract,
             key,
             self.config.tx_timeout,
@@ -202,6 +203,10 @@ impl Client {
         key: KeySet,
         pending_withdrawal_digests: Vec<Bytes32>,
     ) -> Result<(), SyncError> {
+        if pending_withdrawal_digests.is_empty() {
+            // no pending withdrawals
+            return Ok(());
+        }
         let (mut user_data, prev_digest) = self.get_user_data_and_digest(key).await?;
         user_data.withdrawal_status.pending_digests = pending_withdrawal_digests;
         // save user data


### PR DESCRIPTION
1. Added commands to the CLI to check user-data and payment memo. This helps with debugging the status of payment memos and synchronization states.

2. In `determine_withdrawal` and `determine_claim`, we now check the request status of the withdrawal server, and exclude duplicates from `sync_withdrawals`/`sync_claims`. This prevents duplicate requests to the withdrawal server even if `user_data` updates fail during `sync_withdrawals`/`sync_claims`.