### PR TITLE
fix: observer panic bug & better reseting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1715,7 +1715,7 @@ dependencies = [
 
 [[package]]
 name = "balance-prover"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "actix-cors",
  "actix-web",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "block-builder"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "actix-cors",
  "actix-rt",
@@ -2107,7 +2107,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "serde",
 ]
@@ -3581,7 +3581,7 @@ dependencies = [
 
 [[package]]
 name = "intmax2-cli"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "alloy",
  "anyhow",
@@ -3614,7 +3614,7 @@ dependencies = [
 
 [[package]]
 name = "intmax2-client-sdk"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "aes-gcm",
  "alloy",
@@ -3661,7 +3661,7 @@ dependencies = [
 
 [[package]]
 name = "intmax2-interfaces"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -3699,7 +3699,7 @@ dependencies = [
 
 [[package]]
 name = "intmax2-wasm-lib"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "alloy",
  "anyhow",
@@ -3918,7 +3918,7 @@ dependencies = [
 
 [[package]]
 name = "legacy-store-vault-server"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "actix-cors",
  "actix-web",
@@ -5630,7 +5630,7 @@ dependencies = [
 
 [[package]]
 name = "server-common"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "actix-web",
  "common",
@@ -6022,7 +6022,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "store-vault-server"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "actix-cors",
  "actix-web",
@@ -6202,7 +6202,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tests"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "alloy",
  "anyhow",
@@ -6792,7 +6792,7 @@ dependencies = [
 
 [[package]]
 name = "validity-prover"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "actix-cors",
  "actix-web",
@@ -6828,7 +6828,7 @@ dependencies = [
 
 [[package]]
 name = "validity-prover-worker"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -7389,7 +7389,7 @@ dependencies = [
 
 [[package]]
 name = "withdrawal-server"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "actix-cors",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["job-servers/aggregator-prover"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.24"
+version = "0.1.25"
 edition = "2021"
 
 [workspace.dependencies]

--- a/validity-prover/src/app/observer.rs
+++ b/validity-prover/src/app/observer.rs
@@ -234,7 +234,11 @@ impl Observer {
             .await?;
         if local_last_eth_block_number.is_none() {
             let is_synced = self.is_synced(EventType::DepositLeafInserted).await?;
-            if !is_synced {
+            if is_synced {
+                // This means no deposit leaf inserted events though we have synced all events
+                return Ok(Some(Vec::new()));
+            } else {
+                //  We have not synced all events yet
                 return Ok(None);
             }
         }

--- a/validity-prover/src/app/validity_prover.rs
+++ b/validity-prover/src/app/validity_prover.rs
@@ -204,8 +204,7 @@ impl ValidityProver {
             }
             let deposit_tree_root = self.deposit_hash_tree.get_root(block_number as u64).await?;
             if full_block.block.deposit_tree_root != deposit_tree_root {
-                // Reset merkle tree
-                self.reset_merkle_tree(block_number).await?;
+                self.reset_state().await?;
                 return Err(ValidityProverError::DepositTreeRootMismatch(
                     full_block.block.deposit_tree_root,
                     deposit_tree_root,
@@ -230,7 +229,7 @@ impl ValidityProver {
             {
                 Ok(w) => w,
                 Err(e) => {
-                    self.reset_merkle_tree(block_number).await?;
+                    self.reset_state().await?;
                     return Err(ValidityProverError::FailedToUpdateTrees(e.to_string()));
                 }
             };
@@ -276,12 +275,14 @@ impl ValidityProver {
         Ok(())
     }
 
+    /// delete all data from validity witness and each tree after the block number which is one greater than the oldest timestamp of each tree
     #[instrument(skip(self))]
-    async fn reset_merkle_tree(&self, block_number: u32) -> Result<(), ValidityProverError> {
-        tracing::warn!("Reset merkle tree from block number {}", block_number);
-        self.account_tree.reset(block_number as u64).await?;
-        self.block_tree.reset(block_number as u64).await?;
-        self.deposit_hash_tree.reset(block_number as u64).await?;
+    async fn reset_state(&self) -> Result<(), ValidityProverError> {
+        let reset_block_number = self.get_last_block_number().await? as u64 + 1;
+        tracing::warn!("Reset state: reset block number {}", reset_block_number);
+        self.account_tree.reset(reset_block_number).await?;
+        self.block_tree.reset(reset_block_number).await?;
+        self.deposit_hash_tree.reset(reset_block_number).await?;
         Ok(())
     }
 

--- a/validity-prover/src/app/validity_prover.rs
+++ b/validity-prover/src/app/validity_prover.rs
@@ -275,7 +275,7 @@ impl ValidityProver {
         Ok(())
     }
 
-    /// delete all data from validity witness and each tree after the block number which is one greater than the oldest timestamp of each tree
+    // Reset the state of the trees which are not synced with the validity witness
     #[instrument(skip(self))]
     async fn reset_state(&self) -> Result<(), ValidityProverError> {
         let reset_block_number = self.get_last_block_number().await? as u64 + 1;


### PR DESCRIPTION
- Fixed an issue where the observer would panic when `local_last_eth_block_number` was `None` and `is_synced` was `true`
- Fixed a potential issue in reset merkle tree where the reset could be insufficient if the `block_number` argument was too large