### PR TITLE
feat!(withdrawal-server/wasm): add `submit_claim_proof_tx_hash` to ClaimInfo

### DIFF
--- a/.sqlx/query-925c271aa1f900705e6f7e1a318a13dda04d3b27dece5889fb4a61463953282d.json
+++ b/.sqlx/query-925c271aa1f900705e6f7e1a318a13dda04d3b27dece5889fb4a61463953282d.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT \n                status as \"status: SqlClaimStatus\",\n                claim,\n                l1_tx_hash\n            FROM claims\n            WHERE pubkey = $1\n            ",
+  "query": "\n            SELECT \n                status as \"status: SqlClaimStatus\",\n                claim,\n                submit_claim_proof_tx_hash,\n                l1_tx_hash\n            FROM claims\n            WHERE pubkey = $1\n            ",
   "describe": {
     "columns": [
       {
@@ -28,6 +28,11 @@
       },
       {
         "ordinal": 2,
+        "name": "submit_claim_proof_tx_hash",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 3,
         "name": "l1_tx_hash",
         "type_info": "Bpchar"
       }
@@ -40,8 +45,9 @@
     "nullable": [
       false,
       false,
+      true,
       true
     ]
   },
-  "hash": "e8f56279f670e4057330cbe1d6f37d5fb4666606223d300e71a70e66e20947a3"
+  "hash": "925c271aa1f900705e6f7e1a318a13dda04d3b27dece5889fb4a61463953282d"
 }

--- a/interfaces/src/api/withdrawal_server/interface.rs
+++ b/interfaces/src/api/withdrawal_server/interface.rs
@@ -46,6 +46,7 @@ pub struct WithdrawalInfo {
 pub struct ClaimInfo {
     pub status: ClaimStatus,
     pub claim: Claim,
+    pub submit_claim_proof_tx_hash: Option<Bytes32>,
     pub l1_tx_hash: Option<Bytes32>,
 }
 

--- a/wasm/src/js_types/common.rs
+++ b/wasm/src/js_types/common.rs
@@ -286,6 +286,7 @@ impl From<WithdrawalInfo> for JsWithdrawalInfo {
 pub struct JsClaimInfo {
     pub status: String,
     pub claim: JsClaim,
+    pub submit_claim_proof_tx_hash: Option<String>,
     pub l1_tx_hash: Option<String>,
 }
 
@@ -294,6 +295,9 @@ impl From<ClaimInfo> for JsClaimInfo {
         Self {
             status: claim_info.status.to_string(),
             claim: claim_info.claim.into(),
+            submit_claim_proof_tx_hash: claim_info
+                .submit_claim_proof_tx_hash
+                .map(|hash| hash.to_hex()),
             l1_tx_hash: claim_info.l1_tx_hash.map(|hash| hash.to_hex()),
         }
     }

--- a/withdrawal-server/migrations/20250515135804_add_submit_claim_tx_hash.down.sql
+++ b/withdrawal-server/migrations/20250515135804_add_submit_claim_tx_hash.down.sql
@@ -1,2 +1,2 @@
 ALTER TABLE claims
-DROP COLUMN submit_claim_proof_tx_hash CHAR(66);
+DROP COLUMN submit_claim_proof_tx_hash;

--- a/withdrawal-server/migrations/20250515135804_add_submit_claim_tx_hash.down.sql
+++ b/withdrawal-server/migrations/20250515135804_add_submit_claim_tx_hash.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE claims
+DROP COLUMN submit_claim_proof_tx_hash CHAR(66);

--- a/withdrawal-server/migrations/20250515135804_add_submit_claim_tx_hash.up.sql
+++ b/withdrawal-server/migrations/20250515135804_add_submit_claim_tx_hash.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE claims
+ADD COLUMN submit_claim_proof_tx_hash CHAR(66);

--- a/withdrawal-server/src/app/withdrawal_server.rs
+++ b/withdrawal-server/src/app/withdrawal_server.rs
@@ -422,6 +422,7 @@ impl WithdrawalServer {
             SELECT 
                 status as "status: SqlClaimStatus",
                 claim,
+                submit_claim_proof_tx_hash,
                 l1_tx_hash
             FROM claims
             WHERE pubkey = $1
@@ -438,6 +439,9 @@ impl WithdrawalServer {
             claim_infos.push(ClaimInfo {
                 status: record.status.into(),
                 claim,
+                submit_claim_proof_tx_hash: record
+                    .submit_claim_proof_tx_hash
+                    .map(|h| Bytes32::from_hex(&h).unwrap()),
                 l1_tx_hash: record.l1_tx_hash.map(|h| Bytes32::from_hex(&h).unwrap()),
             });
         }


### PR DESCRIPTION
This pull request introduces a new column, `submit_claim_proof_tx_hash`, to the `claims` table and propagates this change throughout the codebase to support its usage. The updates include database migrations, query modifications, and adjustments to related data structures and interfaces.

### Database Schema Changes:
* Added a new column `submit_claim_proof_tx_hash` of type `CHAR(66)` to the `claims` table via an `up` migration and provided a corresponding `down` migration to drop the column. (`withdrawal-server/migrations/20250515135804_add_submit_claim_tx_hash.up.sql`, `withdrawal-server/migrations/20250515135804_add_submit_claim_tx_hash.down.sql`) [[1]](diffhunk://#diff-e8eb0329c931b8daa712fc1ea66e3ab55722c88be5afefc0c26b548f1a0b8ebeR1-R2) [[2]](diffhunk://#diff-3a6cc754441e56c99aa1d06d38092a6bf5c5c5267fa7ccd9d45ad94111d5d0b5R1-R2)

### Query and Data Model Updates:
* Updated the SQL query in `withdrawal-server/src/app/withdrawal_server.rs` and `.sqlx` JSON files to include the new column `submit_claim_proof_tx_hash`. (`.sqlx/query-925c271aa1f900705e6f7e1a318a13dda04d3b27dece5889fb4a61463953282d.json`, `withdrawal-server/src/app/withdrawal_server.rs`) [[1]](diffhunk://#diff-d37c45991a387c8150230d06d662c5185b90358df24c2ca1ccd41f2977484e6bL3-R3) [[2]](diffhunk://#diff-d37c45991a387c8150230d06d662c5185b90358df24c2ca1ccd41f2977484e6bR31-R35) [[3]](diffhunk://#diff-d37c45991a387c8150230d06d662c5185b90358df24c2ca1ccd41f2977484e6bR48-R52) [[4]](diffhunk://#diff-c71fb601e5c4701b73a4f3be9fbe8b6f365e6bb89300524c24f7a163fc3d7693R425)

### Struct and Interface Adjustments:
* Added `submit_claim_proof_tx_hash` as an optional field to the `ClaimInfo` struct in `interface.rs` and updated the `ClaimInfo` population logic to map this field from the query results. (`interfaces/src/api/withdrawal_server/interface.rs`, `withdrawal-server/src/app/withdrawal_server.rs`) [[1]](diffhunk://#diff-1bc48be8b920bf9e0c6fff6fd5db83b6877c941d3f26f84c3d37d64cc5bb9738R49) [[2]](diffhunk://#diff-c71fb601e5c4701b73a4f3be9fbe8b6f365e6bb89300524c24f7a163fc3d7693R442-R444)
* Updated the `JsClaimInfo` struct and its conversion logic to include the new field, ensuring compatibility with JavaScript bindings. (`wasm/src/js_types/common.rs`) [[1]](diffhunk://#diff-9e5821537a2946186e38e2a4a3852837fff3e0324b1c284257358fc40f68bc30R289) [[2]](diffhunk://#diff-9e5821537a2946186e38e2a4a3852837fff3e0324b1c284257358fc40f68bc30R298-R300)