### PR TITLE
fix(validity-prover): start sync only if `is_sync_mode=true`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1715,7 +1715,7 @@ dependencies = [
 
 [[package]]
 name = "balance-prover"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "actix-cors",
  "actix-web",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "block-builder"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "actix-cors",
  "actix-rt",
@@ -2107,7 +2107,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "serde",
 ]
@@ -3581,7 +3581,7 @@ dependencies = [
 
 [[package]]
 name = "intmax2-cli"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "alloy",
  "anyhow",
@@ -3614,7 +3614,7 @@ dependencies = [
 
 [[package]]
 name = "intmax2-client-sdk"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "aes-gcm",
  "alloy",
@@ -3662,7 +3662,7 @@ dependencies = [
 
 [[package]]
 name = "intmax2-interfaces"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -3700,7 +3700,7 @@ dependencies = [
 
 [[package]]
 name = "intmax2-wasm-lib"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "alloy",
  "anyhow",
@@ -3919,7 +3919,7 @@ dependencies = [
 
 [[package]]
 name = "legacy-store-vault-server"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "actix-cors",
  "actix-web",
@@ -5631,7 +5631,7 @@ dependencies = [
 
 [[package]]
 name = "server-common"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "actix-web",
  "common",
@@ -6023,7 +6023,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "store-vault-server"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "actix-cors",
  "actix-web",
@@ -6203,7 +6203,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tests"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "alloy",
  "anyhow",
@@ -6793,7 +6793,7 @@ dependencies = [
 
 [[package]]
 name = "validity-prover"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "actix-cors",
  "actix-web",
@@ -6831,7 +6831,7 @@ dependencies = [
 
 [[package]]
 name = "validity-prover-worker"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -7392,7 +7392,7 @@ dependencies = [
 
 [[package]]
 name = "withdrawal-server"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "actix-cors",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["job-servers/aggregator-prover"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.25"
+version = "0.1.26"
 edition = "2021"
 
 [workspace.dependencies]

--- a/validity-prover/src/api/state.rs
+++ b/validity-prover/src/api/state.rs
@@ -24,6 +24,7 @@ use intmax2_zkp::common::{
     witness::validity_witness::ValidityWitness,
 };
 use std::{sync::Arc, time::Duration};
+use tracing::info;
 
 use server_common::redis::cache::RedisCache;
 
@@ -112,9 +113,12 @@ impl State {
         };
 
         // start jos
-        leader_election.start_job();
-        run_and_switch_observers(Arc::new(rpc_observer), graph_observer).await;
-        validity_prover.clone().start_all_jobs().await.unwrap();
+        if env.is_sync_mode {
+            leader_election.start_job();
+            run_and_switch_observers(Arc::new(rpc_observer), graph_observer).await;
+            validity_prover.start_all_jobs().await?;
+            info!("Started all jobs");
+        }
 
         Ok(Self {
             validity_prover,

--- a/validity-prover/src/app/validity_prover.rs
+++ b/validity-prover/src/app/validity_prover.rs
@@ -474,11 +474,6 @@ impl ValidityProver {
 
     #[instrument(skip(self))]
     pub async fn start_all_jobs(&self) -> Result<(), ValidityProverError> {
-        if !self.config.is_sync_mode {
-            // If is_sync_mode is false, do not start the job
-            return Ok(());
-        }
-
         // clear all tasks
         self.manager.clear_all().await?;
 


### PR DESCRIPTION
This pull request includes updates to the `validity-prover` codebase to improve job management logic, logging, and versioning. The most important changes involve refining conditional behavior for starting jobs, adding logging for better observability, and updating the project version.

### Job management improvements:
* [`validity-prover/src/api/state.rs`](diffhunk://#diff-d564305f34e841ea7310ffea90ecc8ef735f37aabf0ffb97b1f7689978d88203R116-R121): Modified the `State` implementation to ensure `leader_election.start_job()` and `validity_prover.start_all_jobs()` are only executed when `is_sync_mode` is enabled. This ensures jobs are started conditionally based on the environment configuration.
* [`validity-prover/src/app/validity_prover.rs`](diffhunk://#diff-52a5e5ae63336b56e293ee397aabc7c566289398e45517012656fa9d9db5f451L477-L481): Removed redundant conditional checks for `is_sync_mode` within `start_all_jobs`, as this logic is now handled at a higher level in the `State` implementation.

### Logging enhancements:
* [`validity-prover/src/api/state.rs`](diffhunk://#diff-d564305f34e841ea7310ffea90ecc8ef735f37aabf0ffb97b1f7689978d88203R27): Added a `tracing::info` log statement to indicate when all jobs have been successfully started, improving observability of the system's behavior. [[1]](diffhunk://#diff-d564305f34e841ea7310ffea90ecc8ef735f37aabf0ffb97b1f7689978d88203R27) [[2]](diffhunk://#diff-d564305f34e841ea7310ffea90ecc8ef735f37aabf0ffb97b1f7689978d88203R116-R121)

### Version update:
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L22-R22): Updated the package version from `0.1.25` to `0.1.26` to reflect the changes introduced in this pull request.