### PR TITLE
fix: change calling place of `rate_manager.add()` & misc modifications

### DIFF
--- a/cli/src/cli/get.rs
+++ b/cli/src/cli/get.rs
@@ -93,12 +93,15 @@ pub async fn claim_status(key: KeySet) -> Result<(), CliError> {
     println!("Claim status:");
     for (i, claim_info) in claim_info.iter().enumerate() {
         let claim = claim_info.claim.clone();
+        let submit_proof_tx_hash = claim_info
+            .submit_claim_proof_tx_hash
+            .map_or("N/A".to_string(), |h| h.to_hex());
         let l1_tx_hash = claim_info
             .l1_tx_hash
             .map_or("N/A".to_string(), |h| h.to_hex());
         println!(
-            "#{}: recipient: {}, amount: {}, l1_tx_hash: {}, status: {}",
-            i, claim.recipient, claim.amount, l1_tx_hash, claim_info.status
+            "#{}: recipient: {}, amount: {}, submit_proof_tx_hash: {}, l1_tx_hash: {}, status: {}",
+            i, claim.recipient, claim.amount, submit_proof_tx_hash, l1_tx_hash, claim_info.status
         );
     }
     Ok(())

--- a/validity-prover/src/app/observer_common.rs
+++ b/validity-prover/src/app/observer_common.rs
@@ -146,10 +146,10 @@ async fn sync_events_job<O: SyncEvent + 'static>(
                 break;
             }
             Ok(Err(e)) => {
-                error!("Sync events {} job panic: {}", event_type, e);
+                error!("Sync events {} job error: {}", event_type, e);
             }
             Err(e) => {
-                error!("Sync events {} job error: {}", event_type, e);
+                error!("Sync events {} job panic: {}", event_type, e);
             }
         }
         observer


### PR DESCRIPTION
This pull request includes updates to improve logging clarity, enhance functionality in the `ValidityProver` implementation, and adjust rate management logic. Below is a summary of the most significant changes:

### Logging Improvements:
* Updated error messages in `sync_events_job` to swap the terms "panic" and "error" for better accuracy in describing failure scenarios. (`validity-prover/src/app/observer_common.rs`)

### Enhancements to `ValidityProver`:
* Added calls to `self.rate_manager.add` with appropriate keys (`SYNC_VALIDITY_WITNESS_KEY`, `GENERATE_VALIDITY_PROOF_KEY`, `ADD_TASKS_KEY`) in the `ValidityProver` implementation to track rate-limited operations. (`validity-prover/src/app/validity_prover.rs`) [[1]](diffhunk://#diff-52a5e5ae63336b56e293ee397aabc7c566289398e45517012656fa9d9db5f451R196) [[2]](diffhunk://#diff-52a5e5ae63336b56e293ee397aabc7c566289398e45517012656fa9d9db5f451R329) [[3]](diffhunk://#diff-52a5e5ae63336b56e293ee397aabc7c566289398e45517012656fa9d9db5f451R407)

### Rate Management Adjustments:
* Removed redundant `self.rate_manager.add` calls from periodic task loops for syncing witnesses, generating proofs, and adding tasks, as these were already handled elsewhere in the workflow. (`validity-prover/src/app/validity_prover.rs`) [[1]](diffhunk://#diff-52a5e5ae63336b56e293ee397aabc7c566289398e45517012656fa9d9db5f451L439) [[2]](diffhunk://#diff-52a5e5ae63336b56e293ee397aabc7c566289398e45517012656fa9d9db5f451L449) [[3]](diffhunk://#diff-52a5e5ae63336b56e293ee397aabc7c566289398e45517012656fa9d9db5f451L459)

### CLI Output Enhancement:
* Updated the `claim_status` function in the CLI to include `submit_claim_proof_tx_hash` in the output, providing additional transaction details for claims. (`cli/src/cli/get.rs`)