### PR TITLE
fix: emit more heartbeat

### DIFF
--- a/validity-prover/src/api/health.rs
+++ b/validity-prover/src/api/health.rs
@@ -51,7 +51,7 @@ pub async fn health_check(state: Data<State>) -> Result<Json<HealthCheckResponse
             .get_last_heartbeat(key)
             .await
             .map_err(|_| {
-                actix_web::error::ErrorInternalServerError("Failed to get last timestamp")
+                actix_web::error::ErrorInternalServerError("Failed to get last heartbeat")
             })?;
         if let Some(last_timestamp) = last_timestamp {
             if last_timestamp + heartbeat_timeout < current_timestamp {

--- a/validity-prover/src/api/health.rs
+++ b/validity-prover/src/api/health.rs
@@ -46,9 +46,13 @@ pub async fn health_check(state: Data<State>) -> Result<Json<HealthCheckResponse
 
     let current_timestamp = chrono::Utc::now().timestamp() as u64;
     for key in keys.iter() {
-        let last_timestamp = state.rate_manager.last_timestamp(key).await.map_err(|_| {
-            actix_web::error::ErrorInternalServerError("Failed to get last timestamp")
-        })?;
+        let last_timestamp = state
+            .rate_manager
+            .get_last_heartbeat(key)
+            .await
+            .map_err(|_| {
+                actix_web::error::ErrorInternalServerError("Failed to get last timestamp")
+            })?;
         if let Some(last_timestamp) = last_timestamp {
             if last_timestamp + heartbeat_timeout < current_timestamp {
                 return Err(actix_web::error::ErrorInternalServerError(format!(

--- a/validity-prover/src/app/observer_common.rs
+++ b/validity-prover/src/app/observer_common.rs
@@ -104,6 +104,10 @@ async fn sync_events_inner_loop<O: SyncEvent>(
             info!("Stopping sync events because of stop flag, {}", event_type);
             return Ok(());
         }
+        observer
+            .rate_manager()
+            .emit_heartbeat(&sync_event_key(event_type))
+            .await?;
         observer.sync_events(event_type).await?;
     }
 }

--- a/validity-prover/src/app/observer_graph.rs
+++ b/validity-prover/src/app/observer_graph.rs
@@ -241,7 +241,9 @@ impl SyncEvent for TheGraphObserver {
         );
         // continue to sync until local_next_event_id >= onchain_next_event_id with max_query_times
         for _ in 0..self.config.observer_max_query_times {
-            self.rate_manager().add(&sync_event_key(event_type)).await?;
+            self.rate_manager()
+                .emit_heartbeat(&sync_event_key(event_type))
+                .await?;
             self.leader_election.wait_for_leadership().await?;
             local_next_event_id = match event_type {
                 EventType::DepositLeafInserted => {

--- a/validity-prover/src/app/observer_rpc.rs
+++ b/validity-prover/src/app/observer_rpc.rs
@@ -418,7 +418,9 @@ impl SyncEvent for RPCObserver {
         );
         // continue to sync until local_next_event_id >= onchain_next_event_id with max_query_times
         for _ in 0..self.config.observer_max_query_times {
-            self.rate_manager().add(&sync_event_key(event_type)).await?;
+            self.rate_manager()
+                .emit_heartbeat(&sync_event_key(event_type))
+                .await?;
             local_next_event_id = self
                 .sync_and_save_checkpoint(event_type, onchain_next_event_id, local_next_event_id)
                 .await?;

--- a/validity-prover/src/app/rate_manager.rs
+++ b/validity-prover/src/app/rate_manager.rs
@@ -69,22 +69,8 @@ impl RateManager {
             .push(Instant::now());
         drop(counts);
 
-        let current_time = Utc::now().timestamp() as u64;
-        let mut last_timestamps = timeout(self.timeout, self.last_timestamps.lock())
-            .await
-            .map_err(|_| RateManagerError::Timeout("Timeout while adding key".to_string()))?;
-        last_timestamps.insert(key.to_string(), current_time);
+        self.emit_heartbeat(key).await?;
         Ok(())
-    }
-
-    pub async fn last_timestamp(&self, key: &str) -> Result<Option<u64>, RateManagerError> {
-        let last_timestamps = timeout(self.timeout, self.last_timestamps.lock())
-            .await
-            .map_err(|_| {
-                RateManagerError::Timeout("Timeout while getting last timestamp".to_string())
-            })?;
-        let last_timestamp = last_timestamps.get(key).cloned();
-        Ok(last_timestamp)
     }
 
     pub async fn count(&self, key: &str) -> Result<usize, RateManagerError> {
@@ -101,6 +87,26 @@ impl RateManager {
             })
             .unwrap_or(0);
         Ok(count)
+    }
+
+    pub async fn emit_heartbeat(&self, key: &str) -> Result<(), RateManagerError> {
+        let mut last_timestamps = timeout(self.timeout, self.last_timestamps.lock())
+            .await
+            .map_err(|_| {
+                RateManagerError::Timeout("Timeout while emitting heartbeat".to_string())
+            })?;
+        last_timestamps.insert(key.to_string(), Utc::now().timestamp() as u64);
+        Ok(())
+    }
+
+    pub async fn get_last_heartbeat(&self, key: &str) -> Result<Option<u64>, RateManagerError> {
+        let last_timestamps = timeout(self.timeout, self.last_timestamps.lock())
+            .await
+            .map_err(|_| {
+                RateManagerError::Timeout("Timeout while getting last heartbeat".to_string())
+            })?;
+        let last_timestamp = last_timestamps.get(key).cloned();
+        Ok(last_timestamp)
     }
 
     pub async fn set_stop_flag(&self, key: &str, flag: bool) -> Result<(), RateManagerError> {

--- a/validity-prover/src/app/rate_manager.rs
+++ b/validity-prover/src/app/rate_manager.rs
@@ -89,6 +89,7 @@ impl RateManager {
         Ok(count)
     }
 
+    /// Emit a heartbeat for thread health check
     pub async fn emit_heartbeat(&self, key: &str) -> Result<(), RateManagerError> {
         let mut last_timestamps = timeout(self.timeout, self.last_timestamps.lock())
             .await

--- a/validity-prover/src/app/validity_prover.rs
+++ b/validity-prover/src/app/validity_prover.rs
@@ -193,7 +193,9 @@ impl ValidityProver {
                 "sync_validity_witness: syncing block number {}",
                 block_number
             );
-            self.rate_manager.add(SYNC_VALIDITY_WITNESS_KEY).await?;
+            self.rate_manager
+                .emit_heartbeat(SYNC_VALIDITY_WITNESS_KEY)
+                .await?;
             let full_block_with_meta = self
                 .observer_api
                 .get_full_block_with_meta(block_number)
@@ -326,7 +328,9 @@ impl ValidityProver {
         }
 
         loop {
-            self.rate_manager.add(GENERATE_VALIDITY_PROOF_KEY).await?;
+            self.rate_manager
+                .emit_heartbeat(GENERATE_VALIDITY_PROOF_KEY)
+                .await?;
             last_validity_proof_block_number += 1;
 
             // get result from the task manager
@@ -404,7 +408,7 @@ impl ValidityProver {
             .to_validity_pis()
             .unwrap();
         for block_number in (last_validity_prover_block_number + 1)..=to_block_number {
-            self.rate_manager.add(ADD_TASKS_KEY).await?;
+            self.rate_manager.emit_heartbeat(ADD_TASKS_KEY).await?;
             if self.manager.check_task_exists(block_number).await? {
                 break;
             }
@@ -439,6 +443,9 @@ impl ValidityProver {
             tokio::time::interval(Duration::from_secs(self.config.witness_sync_interval));
         loop {
             interval.tick().await;
+            self.rate_manager
+                .emit_heartbeat(SYNC_VALIDITY_WITNESS_KEY)
+                .await?;
             self.sync_validity_witness().await?;
         }
     }
@@ -448,6 +455,9 @@ impl ValidityProver {
             tokio::time::interval(Duration::from_secs(self.config.validity_proof_interval));
         loop {
             interval.tick().await;
+            self.rate_manager
+                .emit_heartbeat(GENERATE_VALIDITY_PROOF_KEY)
+                .await?;
             self.generate_validity_proof().await?;
         }
     }
@@ -457,6 +467,7 @@ impl ValidityProver {
             tokio::time::interval(Duration::from_secs(self.config.add_tasks_interval));
         loop {
             interval.tick().await;
+            self.rate_manager.emit_heartbeat(ADD_TASKS_KEY).await?;
             self.add_tasks().await?;
         }
     }
@@ -467,7 +478,9 @@ impl ValidityProver {
         ));
         loop {
             interval.tick().await;
-            self.rate_manager.add(CLEANUP_INACTIVE_TASKS_KEY).await?;
+            self.rate_manager
+                .emit_heartbeat(CLEANUP_INACTIVE_TASKS_KEY)
+                .await?;
             self.manager.cleanup_inactive_tasks().await?;
         }
     }


### PR DESCRIPTION
I've modified the heartbeat sending mechanism to occur at the beginning of each loop's internal process.

Previously, heartbeats were only sent within lower-level loops, but this created a scenario where heartbeats could be missed when higher-level loops exited before executing lower-level loops.

By implementing heartbeat transmission in higher-level loops as well, this issue has been resolved.