### PR TITLE
fix: change `generate_transfer_receipt` parameters

### DIFF
--- a/client-sdk/src/client/client.rs
+++ b/client-sdk/src/client/client.rs
@@ -829,10 +829,10 @@ impl Client {
     pub async fn generate_transfer_receipt(
         &self,
         key: KeySet,
-        transfer_digest: Bytes32,
-        receiver: U256,
+        tx_digest: Bytes32,
+        transfer_index: u32,
     ) -> Result<String, ClientError> {
-        generate_transfer_receipt(self, key, transfer_digest, receiver).await
+        generate_transfer_receipt(self, key, tx_digest, transfer_index).await
     }
 
     pub async fn validate_transfer_receipt(

--- a/client-sdk/src/client/error.rs
+++ b/client-sdk/src/client/error.rs
@@ -2,6 +2,7 @@ use intmax2_interfaces::{
     api::error::ServerError,
     data::{encryption::errors::BlsEncryptionError, proof_compression::ProofCompressionError},
 };
+use intmax2_zkp::common::error::CommonError;
 
 use crate::external_api::contract::error::BlockchainError;
 
@@ -23,6 +24,12 @@ pub enum ClientError {
 
     #[error(transparent)]
     SyncError(#[from] SyncError),
+
+    #[error(transparent)]
+    CommonError(#[from] CommonError),
+
+    #[error("General error: {0}")]
+    GeneralError(String),
 
     #[error(transparent)]
     ReceiveValidationError(#[from] ReceiveValidationError),

--- a/client-sdk/src/client/fee_payment.rs
+++ b/client-sdk/src/client/fee_payment.rs
@@ -285,7 +285,7 @@ pub async fn select_unused_fees(
             store_vault_server,
             validity_prover,
             memo.transfer_data.transfer.recipient.to_pubkey().unwrap(),
-            &memo.meta,
+            memo.meta.timestamp,
             &memo.transfer_data,
         )
         .await

--- a/client-sdk/src/client/receipt.rs
+++ b/client-sdk/src/client/receipt.rs
@@ -1,12 +1,8 @@
 use base64::{prelude::BASE64_STANDARD, Engine};
 use intmax2_interfaces::data::{
-    data_type::DataType, encryption::BlsEncryption, meta_data::MetaData,
-    transfer_data::TransferData,
+    data_type::DataType, encryption::BlsEncryption, transfer_data::TransferData, tx_data::TxData,
 };
-use intmax2_zkp::{
-    common::signature_content::key_set::KeySet,
-    ethereum_types::{bytes32::Bytes32, u256::U256},
-};
+use intmax2_zkp::{common::signature_content::key_set::KeySet, ethereum_types::bytes32::Bytes32};
 use serde::{Deserialize, Serialize};
 
 use crate::client::receive_validation::validate_receive;
@@ -17,7 +13,7 @@ use super::{client::Client, error::ClientError, strategy::common::fetch_single_d
 #[serde(rename_all = "camelCase")]
 pub struct TransferReceipt {
     pub data: TransferData,
-    pub meta: MetaData,
+    pub timestamp: u64,
 }
 
 impl BlsEncryption for TransferReceipt {}
@@ -25,17 +21,28 @@ impl BlsEncryption for TransferReceipt {}
 pub async fn generate_transfer_receipt(
     client: &Client,
     key: KeySet,
-    transfer_digest: Bytes32,
-    receiver: U256,
+    tx_digest: Bytes32,
+    transfer_index: u32,
 ) -> Result<String, ClientError> {
-    let (meta, data) = fetch_single_data(
+    let (meta, tx_data) = fetch_single_data::<TxData>(
         client.store_vault_server.as_ref(),
         key,
-        DataType::Transfer,
-        transfer_digest,
+        DataType::Tx,
+        tx_digest,
     )
     .await?;
-    let encrypted_data = TransferReceipt { data, meta }.encrypt(receiver, None)?;
+    let data = tx_data.get_transfer_data(key.pubkey, transfer_index)?;
+    if !data.transfer.recipient.is_pubkey {
+        return Err(ClientError::GeneralError(
+            "Recipient is not a pubkey address".to_string(),
+        ));
+    }
+    let receiver = data.transfer.recipient.to_pubkey()?;
+    let encrypted_data = TransferReceipt {
+        data,
+        timestamp: meta.timestamp,
+    }
+    .encrypt(receiver, None)?;
     let encrypted_data_base64 = BASE64_STANDARD.encode(&encrypted_data);
     Ok(encrypted_data_base64)
 }
@@ -56,7 +63,7 @@ pub async fn validate_transfer_receipt(
         client.store_vault_server.as_ref(),
         client.validity_prover.as_ref(),
         key.pubkey,
-        transfer_receipt.meta.timestamp,
+        transfer_receipt.timestamp,
         &transfer_receipt.data,
     )
     .await?;

--- a/client-sdk/src/client/receipt.rs
+++ b/client-sdk/src/client/receipt.rs
@@ -56,7 +56,7 @@ pub async fn validate_transfer_receipt(
         client.store_vault_server.as_ref(),
         client.validity_prover.as_ref(),
         key.pubkey,
-        &transfer_receipt.meta,
+        transfer_receipt.meta.timestamp,
         &transfer_receipt.data,
     )
     .await?;

--- a/client-sdk/src/client/receive_validation.rs
+++ b/client-sdk/src/client/receive_validation.rs
@@ -4,9 +4,8 @@ use intmax2_interfaces::{
         validity_prover::interface::ValidityProverClientInterface,
     },
     data::{
-        encryption::errors::BlsEncryptionError, meta_data::MetaData,
-        proof_compression::ProofCompressionError, transfer_data::TransferData,
-        validation::Validation as _,
+        encryption::errors::BlsEncryptionError, proof_compression::ProofCompressionError,
+        transfer_data::TransferData, validation::Validation as _,
     },
 };
 use intmax2_zkp::{
@@ -46,7 +45,7 @@ pub async fn validate_receive(
     store_vault_server: &dyn StoreVaultClientInterface,
     validity_prover: &dyn ValidityProverClientInterface,
     recipient_pubkey: U256,
-    meta: &MetaData,
+    transfer_timestamp: u64,
     transfer_data: &TransferData,
 ) -> Result<Transfer, ReceiveValidationError> {
     transfer_data
@@ -64,7 +63,7 @@ pub async fn validate_receive(
         .get_block_number_by_tx_tree_root(transfer_data.tx_tree_root)
         .await?;
     if block_number.is_none() {
-        return Err(ReceiveValidationError::TxIsNotSettled(meta.timestamp));
+        return Err(ReceiveValidationError::TxIsNotSettled(transfer_timestamp));
     }
     let sender_proof_set = fetch_sender_proof_set(
         store_vault_server,

--- a/interfaces/src/data/tx_data.rs
+++ b/interfaces/src/data/tx_data.rs
@@ -7,7 +7,7 @@ use intmax2_zkp::{
         trees::{transfer_tree::TransferTree, tx_tree::TxMerkleProof},
         witness::spent_witness::SpentWitness,
     },
-    constants::{NUM_TRANSFERS_IN_TX, TRANSFER_TREE_HEIGHT},
+    constants::TRANSFER_TREE_HEIGHT,
     ethereum_types::{bytes32::Bytes32, u256::U256},
     utils::poseidon_hash_out::PoseidonHashOut,
 };
@@ -31,13 +31,13 @@ impl TxData {
         sender: U256,
         transfer_index: u32,
     ) -> Result<TransferData, CommonError> {
-        if transfer_index >= NUM_TRANSFERS_IN_TX as u32 {
+        let transfers = self.spent_witness.transfers.clone();
+        if transfer_index >= transfers.len() as u32 {
             return Err(CommonError::InvalidData(format!(
                 "transfer index: {} is out of range",
                 transfer_index
             )));
         }
-        let transfers = self.spent_witness.transfers.clone();
         let mut transfer_tree = TransferTree::new(TRANSFER_TREE_HEIGHT);
         for transfer in &transfers {
             transfer_tree.push(*transfer);

--- a/interfaces/src/data/tx_data.rs
+++ b/interfaces/src/data/tx_data.rs
@@ -1,8 +1,13 @@
 use serde::{Deserialize, Serialize};
 
-use super::{encryption::BlsEncryption, validation::Validation};
+use super::{encryption::BlsEncryption, transfer_data::TransferData, validation::Validation};
 use intmax2_zkp::{
-    common::{trees::tx_tree::TxMerkleProof, witness::spent_witness::SpentWitness},
+    common::{
+        error::CommonError,
+        trees::{transfer_tree::TransferTree, tx_tree::TxMerkleProof},
+        witness::spent_witness::SpentWitness,
+    },
+    constants::{NUM_TRANSFERS_IN_TX, TRANSFER_TREE_HEIGHT},
     ethereum_types::{bytes32::Bytes32, u256::U256},
     utils::poseidon_hash_out::PoseidonHashOut,
 };
@@ -17,8 +22,40 @@ pub struct TxData {
     pub spent_witness: SpentWitness, // to update sender's private state
 
     // Ephemeral key to query the sender proof set
-    // This is not necessary for sender but added for logging purpose
     pub sender_proof_set_ephemeral_key: U256,
+}
+
+impl TxData {
+    pub fn get_transfer_data(
+        &self,
+        sender: U256,
+        transfer_index: u32,
+    ) -> Result<TransferData, CommonError> {
+        if transfer_index >= NUM_TRANSFERS_IN_TX as u32 {
+            return Err(CommonError::InvalidData(format!(
+                "transfer index: {} is out of range",
+                transfer_index
+            )));
+        }
+        let transfers = self.spent_witness.transfers.clone();
+        let mut transfer_tree = TransferTree::new(TRANSFER_TREE_HEIGHT);
+        for transfer in &transfers {
+            transfer_tree.push(*transfer);
+        }
+        let transfer_merkle_tree = transfer_tree.prove(transfer_index as u64);
+        Ok(TransferData {
+            sender_proof_set_ephemeral_key: self.sender_proof_set_ephemeral_key,
+            sender_proof_set: None,
+            sender,
+            tx: self.spent_witness.tx,
+            tx_index: self.tx_index,
+            tx_merkle_proof: self.tx_merkle_proof.clone(),
+            tx_tree_root: self.tx_tree_root,
+            transfer: transfers[transfer_index as usize],
+            transfer_index,
+            transfer_merkle_proof: transfer_merkle_tree,
+        })
+    }
 }
 
 impl BlsEncryption for TxData {}

--- a/wasm/js-test/src/receipt.ts
+++ b/wasm/js-test/src/receipt.ts
@@ -1,4 +1,4 @@
-import { fetch_tx_history, generate_intmax_account_from_eth_key, generate_transfer_receipt, JsMetaDataCursor, validate_transfer_receipt, } from '../pkg';
+import { generate_intmax_account_from_eth_key, generate_transfer_receipt, validate_transfer_receipt, } from '../pkg';
 import { env, config } from './setup';
 
 async function main() {
@@ -8,14 +8,7 @@ async function main() {
     console.log(`privkey`, privkey);
     console.log(`pubkey`, key.pubkey);
 
-    const cursor = new JsMetaDataCursor(null, "asc", null);
-    const tx_history = await fetch_tx_history(config, key.privkey, cursor);
-    if (tx_history.history.length === 0) {
-        console.log("No transfer history found");
-        return;
-    }
-    const tx_data = tx_history.history[0];
-    const tx_digest = tx_data.meta.digest;
+    const tx_digest = "0xd1e845b5c4ad76ed15b75606f280ec1b3cb24c153f12da01a4c0e08490a6b9b9"; // self transfer tx digest in dev env
     const transfer_index = 0; // the first transfer
     console.log(`tx_digest: ${tx_digest}`);
 

--- a/wasm/js-test/src/receipt.ts
+++ b/wasm/js-test/src/receipt.ts
@@ -1,4 +1,4 @@
-import { fetch_transfer_history, generate_intmax_account_from_eth_key, generate_transfer_receipt, get_derive_path_list, JsDerive, JsMetaDataCursor, save_derive_path, validate_transfer_receipt, } from '../pkg';
+import { fetch_tx_history, generate_intmax_account_from_eth_key, generate_transfer_receipt, JsMetaDataCursor, validate_transfer_receipt, } from '../pkg';
 import { env, config } from './setup';
 
 async function main() {
@@ -9,25 +9,23 @@ async function main() {
     console.log(`pubkey`, key.pubkey);
 
     const cursor = new JsMetaDataCursor(null, "asc", null);
-    const transfer_history = await fetch_transfer_history(config, key.privkey, cursor);
-    if (transfer_history.history.length === 0) {
+    const tx_history = await fetch_tx_history(config, key.privkey, cursor);
+    if (tx_history.history.length === 0) {
         console.log("No transfer history found");
         return;
     }
-    const transfer_data = transfer_history.history[0].data;
-    const transfer_digest = transfer_history.history[0].meta.digest;
-    const recipient = transfer_data.transfer.recipient.data;
-    console.log(`transfer_digest: ${transfer_digest}`);
-    console.log(`recipient: ${recipient}`);
+    const tx_data = tx_history.history[0];
+    const tx_digest = tx_data.meta.digest;
+    const transfer_index = 0; // the first transfer
+    console.log(`tx_digest: ${tx_digest}`);
 
-    const receipt = await generate_transfer_receipt(config, key.privkey, transfer_digest, recipient);
+    const receipt = await generate_transfer_receipt(config, key.privkey, tx_digest, transfer_index);
     console.log(`size of receipt: ${receipt.length}`);
 
     // verify the receipt
     const recovered_transfer_data = await validate_transfer_receipt(config, key.privkey, receipt)
     console.log(`recovered transfer amount: ${recovered_transfer_data.transfer.amount}`);
 }
-
 
 main().then(() => {
     process.exit(0);

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -398,16 +398,15 @@ pub async fn make_history_backup(
 pub async fn generate_transfer_receipt(
     config: &Config,
     private_key: &str,
-    transfer_digest: &str,
-    receiver: &str,
+    tx_digest: &str,
+    transfer_index: u32,
 ) -> Result<String, JsError> {
     init_logger();
     let key = str_privkey_to_keyset(private_key)?;
-    let transfer_digest = parse_bytes32(transfer_digest)?;
-    let receiver = parse_bytes32(receiver)?.into();
+    let transfer_digest = parse_bytes32(tx_digest)?;
     let client = get_client(config);
     let receipt = client
-        .generate_transfer_receipt(key, transfer_digest, receiver)
+        .generate_transfer_receipt(key, transfer_digest, transfer_index)
         .await?;
     Ok(receipt)
 }

--- a/withdrawal-server/src/app/withdrawal_server.rs
+++ b/withdrawal-server/src/app/withdrawal_server.rs
@@ -528,7 +528,7 @@ impl WithdrawalServer {
                 self.store_vault_server.as_ref(),
                 &self.validity_prover,
                 key.pubkey,
-                &meta,
+                meta.timestamp,
                 &transfer_data,
             )
             .await


### PR DESCRIPTION
The `transfer_digest` parameter in `generate_transfer_receipt` was a value that the sender side could not obtain. In this PR, I change the parameters to `tx_digest` and `transfer_index`, which are values that the sender side can obtain.